### PR TITLE
Some extra functionality and minor appearance changes

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -32,13 +32,15 @@ Citizen.CreateThread(function()
         DisableControlAction(0, 164, true) -- 4
         DisableControlAction(0, 165, true) -- 5
         DisableControlAction(0, 289, true) -- F2
-        if IsDisabledControlJustPressed(1,289) and not invopen then
-            TriggerEvent("randPickupAnim")
-            TriggerServerEvent("hsn-inventory:server:openInventory",{type = 'drop',id = currentDrop})
-        end
-        for k, v in pairs(keys) do
-            if IsDisabledControlJustReleased(0, v) then
-                TriggerServerEvent("hsn-inventory:server:useItemfromSlot",k)
+        if not invopen then
+            if IsDisabledControlJustPressed(1,289) then
+                TriggerEvent("randPickupAnim")
+                TriggerServerEvent("hsn-inventory:server:openInventory",{type = 'drop',id = currentDrop})
+            end
+            for k, v in pairs(keys) do
+                if IsDisabledControlJustReleased(0, v) then
+                    TriggerServerEvent("hsn-inventory:server:useItemfromSlot",k)
+                end
             end
         end
         if IsPedInAnyVehicle(PlayerPedId(), false) then

--- a/client.lua
+++ b/client.lua
@@ -64,7 +64,7 @@ Citizen.CreateThread(function()
                         local plate = GetVehicleNumberPlateText(vehicle)
                         OpenTrunk(plate)
                     else
-                       TriggerEvent('notification','Car locked',2)
+                       TriggerEvent('notification','This vehicle is locked',2)
                     end
                 end
             end
@@ -317,7 +317,7 @@ AddEventHandler("hsn-inventory:addAmmo",function(item, name)
                 TriggerServerEvent("hsn-inventory:server:addweaponAmmo",curweaponSlot,item.count)
                 TaskReloadWeapon(playerPed)
                 SetPedAmmo(playerPed, weapon, newAmmo)
-                TriggerEvent("notification","Reloaded")
+                TriggerEvent("notification","Reloaded", 1)
                 TriggerServerEvent("hsn-inventory:client:removeItem",name,1)
             else
                 TriggerEvent("notification","Max Ammo")
@@ -357,7 +357,7 @@ RegisterCommand("robplayer",function()
     if closestPlayer ~= -1 and closestDistance <= 3.0 then
         TriggerServerEvent("hsn-inventory:server:robPlayer",GetPlayerServerId(GetClosestPlayer))
     else
-        TriggerEvent("notification",'No one is nearby')
+        TriggerEvent("notification",'There is nobody nearby')
     end
 end)
 
@@ -408,6 +408,15 @@ function SetNuiFocusAdvanced(hasFocus, hasCursor, allowMovement)
         end)
     end
 end
+--[[ Disabled by default, remove comment block to use mythic_notify for notifications
+RegisterNetEvent("notification")
+AddEventHandler("notification",function(message, mtype)
+    if mtype == 1 then mtype = { ['background-color'] = 'rgba(55,55,175)', ['color'] = 'white' }
+    elseif not mtype or mtype == 2 then mtype = { ['background-color'] = 'rgba(175,55,55)', ['color'] = 'white' }
+    end
+    TriggerEvent('mythic_notify:client:SendAlert', {type = 'inform', text = message, length = 2500,style = mtype})
+end)
+]]
 
 RegisterCommand('closeinv', function()
         TriggerEvent("hsn-inventory:client:closeInventory")

--- a/client.lua
+++ b/client.lua
@@ -71,6 +71,7 @@ end
 OpenTrunk = function(trunkid)
     TriggerServerEvent("hsn-inventory:server:openInventory",{type = 'trunk',id = 'trunk-'..trunkid})
 end
+
 RegisterNetEvent("hsn-inventory:client:openInventory")
 AddEventHandler("hsn-inventory:client:openInventory",function(inventory,other)
     invopen = true
@@ -88,7 +89,8 @@ AddEventHandler("hsn-inventory:client:openInventory",function(inventory,other)
         rightinventory = other
     })
     TriggerServerEvent("hsn-inventory:setcurrentInventory",other)
-    SetNuiFocusAdvanced(true, true)
+    if other == nil then movement = true else movement = false end
+    SetNuiFocusAdvanced(true, true, movement)
 end)
 
 
@@ -357,7 +359,7 @@ Citizen.CreateThread(function()
 end)
 
 local nui_focus = {false, false}
-function SetNuiFocusAdvanced(hasFocus, hasCursor)
+function SetNuiFocusAdvanced(hasFocus, hasCursor, allowMovement)
     SetNuiFocus(hasFocus, hasCursor)
     SetNuiFocusKeepInput(hasFocus)
     nui_focus = {hasFocus, hasCursor}
@@ -375,8 +377,10 @@ function SetNuiFocusAdvanced(hasFocus, hasCursor)
                 end
                 EnableControlAction(0, 249, true) -- N for PTT
                 EnableControlAction(0, 20, true) -- Z for proximity
-                EnableControlAction(0, 30, true) -- movement
-                EnableControlAction(0, 31, true) -- movement
+                if allowMovement then
+                    EnableControlAction(0, 30, true) -- movement
+                    EnableControlAction(0, 31, true) -- movement
+                end
                 if not nui_focus[1] then
                     ticks = ticks + 1
                     if (IsDisabledControlJustReleased(0, 200, true) or ticks > 20) then

--- a/client.lua
+++ b/client.lua
@@ -327,7 +327,7 @@ end)
 
 RegisterNetEvent("hsn-inventory:client:esxUseItem")
 AddEventHandler("hsn-inventory:client:esxUseItem",function(item)
-    TriggerServerEvent("esx:useItem",item)
+    TriggerServerEvent("esx:useItem",item.name)
 end)
 
 RegisterCommand("robplayer",function()

--- a/client.lua
+++ b/client.lua
@@ -327,7 +327,7 @@ end)
 
 RegisterNetEvent("hsn-inventory:client:esxUseItem")
 AddEventHandler("hsn-inventory:client:esxUseItem",function(item)
-    TriggerServerEvent("esx:useItem",item.name)
+    TriggerServerEvent("esx:useItem",item)
 end)
 
 RegisterCommand("robplayer",function()

--- a/config.lua
+++ b/config.lua
@@ -7,6 +7,8 @@ Config.DurabilityDecraseAmount = {
 
 
 Config.Shops = {
+
+    -- Regular shop
     {
         coords = vector3(316.3667, -200.783, 54.086),
         blip = {
@@ -27,10 +29,47 @@ Config.Shops = {
                 name = 'WEAPON_PISTOL',
                 price = 25,
                 count = 1,
-                metadata = {}
+                metadata = { weaponlicense = 'HSN', },
+            },
+            {
+                name = 'hsn_pistol_ammo',
+                price = 1,
+                count = 10,
+            },
+            {
+                name = 'identification',
+                price = 15,
+                count = 1
             },
         },
     },
+
+    -- MRPD Armoury
+    {
+        job = 'police',
+        coords = vector3(452.27, -980.1, 30.6),
+        blip = {
+            id = 110,
+            name = "Shop",
+            color = 29,
+            scale = 0.6,
+        },
+        name = 'Armoury',
+        inventory = {
+            {
+                name = 'WEAPON_PISTOL',
+                price = 25,
+                count = 1,
+                metadata = { weaponlicense = 'POL',},
+            },
+            {
+                name = 'hsn_pistol_ammo',
+                price = 1,
+                count = 10,
+            },
+        },
+    },
+
 }
 
 

--- a/config.lua
+++ b/config.lua
@@ -50,7 +50,7 @@ Config.Shops = {
         coords = vector3(452.27, -980.1, 30.6),
         blip = {
             id = 110,
-            name = "Shop",
+            name = "Armoury",
             color = 29,
             scale = 0.6,
         },

--- a/html/script.js
+++ b/html/script.js
@@ -1,3 +1,6 @@
+$('document').ready(function() {
+    $('.inventory-main').hide()
+});
 
     var disabled = false
     var drag = false
@@ -21,7 +24,7 @@
         } else {
             $(".inventory-main").fadeOut(300);
             $('.inventory-main').hide()
-            $(".item-slot").css("border", "1px solid rgba(255, 255, 255, 0.1)");
+            //$(".item-slot").css("border", "1px solid rgba(255, 255, 255, 0.1)");
             $(".item-slot").remove();
             $(".ItemBoxes").remove();
             $(".inventory-main-leftside").find(".item-slot").remove();
@@ -29,7 +32,7 @@
             toplamkg = 0
         }
     }
-    console.log("[hsn-inventory] = Successfully Loaded :)")
+    //console.log("[hsn-inventory] = Successfully Loaded :)")
     Display(false)
     window.addEventListener('message', function(event) {
         if (event.data.message == 'openinventory') {
@@ -76,33 +79,34 @@
             quality = 100
         }
         var color = "#0bb80b"
-        var text = "PERFECT"
+        var text = ''
         var width = 100
         if (quality == 100) {
             color = "#0bb80b",
-            text = parseInt(quality).toFixed(2),
+            text = '',
             width = quality
         } else if (quality >= 80 && quality <= 100) {
             color = "#0bb80b",
-            text = parseInt(quality).toFixed(2),
+            text = '',
             width = quality
         } else if (quality >= 50 && quality <= 80) {
             color = "#0bb80b81",
-            text = parseInt(quality).toFixed(2),
+            text = '',
             width = quality
         } else if (quality >= 20 && quality <= 50) {
-            color = "#ca790fcb",
-            text = parseInt(quality).toFixed(2),
+            color = "#ca250fcb",
+            text = '',
             width = quality
         } else if (quality >= 1 && quality <= 20) {
-            color = parseInt(quality).toFixed(2),
-            text = "BAD",
+            color = '#a31a1acb',
+            text = '',
             width = quality
         } else if (quality == 0) {
             color = "crimson",
-            text = "BROKEN",
+            text = '',
             width = 100
         }
+        //parseInt(quality).toFixed(2)
         return [color = color,text = text,width = width];
 
     }
@@ -304,9 +308,9 @@
             $(".iteminfo").fadeIn(100);
             $(".iteminfo-label").html('<p>'+Item.label+'</p>')
             if (Item.metadata.description != undefined) {
-                $(".iteminfo-description").html('<p><strong>'+Item.description+'<br>'+Item.metadata.description+'</p></strong>')
+                $(".iteminfo-description").html('<p>'+Item.description+'<br>'+Item.metadata.description+'</p>')
             } else {
-                $(".iteminfo-description").html('<p><strong>'+Item.description+'<p><strong>')
+                $(".iteminfo-description").html('<p>'+Item.description+'</p>')
             }
             if ((Item.name).split("_")[0] == "WEAPON") {
                 if (Item.metadata.weaponlicense == null || undefined) {
@@ -318,9 +322,9 @@
                 if (Item.metadata.ammo == null || undefined) {
                     Item.metadata.ammo = "Unknown"
                 }
-                $(".iteminfo-description").append('<p>Weapon License: <strong>'+Item.metadata.weaponlicense+'<p><strong>')
-                $(".iteminfo-description").append('<p>Durability: <strong>'+parseInt(Item.metadata.durability).toFixed(2)+''+'%<p><strong>')
-                $(".iteminfo-description").append('<p>Weapon Ammo : <strong>'+Item.metadata.ammo+'<p><strong>')
+                $(".iteminfo-description").append('<p>Serial Number: <strong>'+Item.metadata.weaponlicense+'</p></strong>')
+                $(".iteminfo-description").append('<p>Durability: <strong>'+parseInt(Item.metadata.durability).toFixed(2)+''+'%</p></strong>')
+                $(".iteminfo-description").append('<p>Weapon Ammo : <strong>'+Item.metadata.ammo+'</p></strong>')
             }
         } else {
             $(".iteminfo").fadeOut(100);
@@ -355,6 +359,9 @@
         
         Display(false)
     });
+
+
+    
 
     SwapItems = function(fromInventory, toInventory, fromSlot, toSlot) {
         fromItem = fromInventory.find("[inventory-slot=" + fromSlot + "]").data("ItemData");

--- a/html/style.css
+++ b/html/style.css
@@ -220,17 +220,18 @@
     position: absolute;
     bottom: 2vh;
     width: 100%;
-    height: 1.8vh;
+    margin-left: 1px;
+    height: 0.6vh;
     line-height: 1.6vh;
     background-color: rgba(32, 6, 6, 0.15);
 }
 
 .item-slot-durability-bar {
     position: absolute;
-    height: 15px;
-    width: 100%;
+    height: 0.6vh;
+    max-width: calc(100% - 2px);
     text-align: center;
-    box-shadow: inset 0 0 .25vh 0 rgba(0, 0, 0, 0.2);
+    box-shadow: 0 0 1px 1px rgba(0,0,0,0.5) inset;
 }
 
 

--- a/html/style.css
+++ b/html/style.css
@@ -10,14 +10,13 @@
     height: 500px;
     padding: 20px;
     /*background-color: rgba(0, 0, 0, 0.2);*/
-    position: relative;
+    position: fixed;
     margin: auto;
     opacity: 0.9;
     top: 50%;
     left: 50%;
-    margin-left: -600px;
-    margin-top: -250px;
     display: block;
+    transform: translate(-50%, -50%);
 }
 
 .inventory-main-leftside {

--- a/server.lua
+++ b/server.lua
@@ -27,7 +27,7 @@ exports.ghmattimysql:ready(function()
     end)
     print('[^2hsn-inventory^0] - Started!')
     print('[^2hsn-inventory^0] - Items are created!')
-    print('^1[hsn-inventory] - Don\'t restart this script while players in game!^0')
+    print('^1[hsn-inventory] - Don\'t restart this script while players in game !')
 end)
 
 
@@ -48,10 +48,11 @@ IfInventoryCanCarry = function(inventory, maxweight, newWeight)
 	return returnData
 end
 
-GetRandomLicense = function()
+GetRandomLicense = function(text)
+    if not text then text = 'HSN' end
     local random = math.random(111111,999999)
     local random2 = math.random(111111,999999)
-    local license = random..'HSN'..random2
+    local license = ('%s%s%s'):format(random, text, random2)
     return license
 end
 
@@ -89,10 +90,10 @@ AddPlayerInventory = function(identifier,item, count, slot, metadata)
                         if metadata == nil then
                             metadata = {}
                             metadata.durability = 100
-                            metadata.weaponlicense = GetRandomLicense()
                             metadata.ammo = 0
                         end
-                            playerInventory[identifier][i] = {name = item ,label = ESXItems[item].label , weight = ESXItems[item].weight, slot = i, count = count, description = ESXItems[item].description, metadata = metadata or {}, stackable = false, closeonuse = ESXItems[item].closeonuse} -- because weapon :)
+                        metadata.weaponlicense = GetRandomLicense(metadata.weaponlicense)
+                        playerInventory[identifier][i] = {name = item ,label = ESXItems[item].label , weight = ESXItems[item].weight, slot = i, count = count, description = ESXItems[item].description, metadata = metadata or {}, stackable = false, closeonuse = ESXItems[item].closeonuse} -- because weapon :)
                         break
                     end
                 end
@@ -103,7 +104,7 @@ AddPlayerInventory = function(identifier,item, count, slot, metadata)
                     if playerInventory[identifier][i] == nil then
                         if metadata == nil then
                             metadata = {}
-                            metadata.description = getIdentificationData(xPlayer)
+                            metadata.description = getPlayerIdentification(xPlayer)
                         end
                             playerInventory[identifier][i] = {name = item ,label = ESXItems[item].label , weight = ESXItems[item].weight, slot = i, count = count, description = ESXItems[item].description, metadata = metadata or {}, stackable = false, closeonuse = ESXItems[item].closeonuse}
                         break
@@ -231,7 +232,7 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                         TriggerEvent("hsn-inventory:onAddInventoryItem",targetplayer.source,data.toItem.name,data.toItem.count)
                         TriggerEvent("hsn-inventory:onRemoveInventoryItem",targetplayer.source,data.fromItem.name,data.fromItem.count)
                     else
-                        TriggerClientEvent("notification",src,"Player can not carry this item",2)
+                        TriggerClientEvent("notification",src,"You can not carry this item",2)
                     end
                 elseif data.type == 'freeslot' then
                     if IfInventoryCanCarry(playerInventory[targetplayer.identifier],ESX.GetConfig().MaxWeight, (data.item.weight * data.item.count))  then
@@ -241,7 +242,7 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                         TriggerEvent("hsn-inventory:onRemoveInventoryItem",src,data.item.name,data.item.count)
                         TriggerEvent("hsn-inventory:onAddInventoryItem",targetplayer.source,data.item.name,data.item.count)
                     else
-                        TriggerClientEvent("notification",src,"Player can not carry this item",2)
+                        TriggerClientEvent("notification",src,"You can not carry this item",2)
                     end
                 elseif data.type == 'yarimswap' then
                     if IfInventoryCanCarry(playerInventory[targetplayer.identifier],ESX.GetConfig().MaxWeight, (data.item.weight * data.item.count))  then
@@ -249,7 +250,7 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                         playerInventory[Player.identifier][data.fromSlot] = {name = data.oldslotItem.name ,label = data.oldslotItem.label, weight = data.oldslotItem.weight, slot = data.fromSlot, count = data.oldslotItem.count, description = data.oldslotItem.description, metadata = data.oldslotItem.metadata, stackable = data.oldslotItem.stackable, closeonuse = ESXItems[data.oldslotItem.name].closeonuse}
                         playerInventory[targetplayer.identifier][data.toSlot] = {name = data.newslotItem.name ,label = data.newslotItem.label, weight = data.newslotItem.weight, slot = data.toSlot, count = data.newslotItem.count, description = data.newslotItem.description, metadata = data.newslotItem.metadata, stackable = data.newslotItem.stackable, closeonuse = ESXItems[data.newslotItem.name].closeonuse}
                     else
-                        TriggerClientEvent("notification",src,"Player can not carry this item",2)
+                        TriggerClientEvent("notification",src,"You can not carry this item",2)
                     end
                 end
             end
@@ -267,7 +268,7 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                         TriggerEvent("hsn-inventory:RemoveAddInventoryItem",src,data.toItem.name,data.toItem.count)
                         TriggerEvent("hsn-inventory:onAddInventoryItem",src,data.fromItem.name,data.fromItem.count)
                     else
-                        TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                        TriggerClientEvent("notification",src,"You can not carry this item",2)
                     end
                 elseif data.type == 'freeslot' then
                     if IfInventoryCanCarry(playerInventory[Player.identifier],ESX.GetConfig().MaxWeight, (data.item.weight * data.item.count))  then
@@ -277,7 +278,7 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                         TriggerEvent("hsn-inventory:onAddInventoryItem",src,data.item.name,data.item.count)
                         TriggerEvent("hsn-inventory:onRemoveInventoryItem",targetplayer.source,data.item.name,data.item.count)
                     else
-                        TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                        TriggerClientEvent("notification",src,"You can not carry this item",2)
                     end
                 elseif data.type == 'yarimswap' then
                     if IfInventoryCanCarry(playerInventory[Player.identifier],ESX.GetConfig().MaxWeight, (data.newslotItem.weight * data.newslotItem.count)) then
@@ -285,7 +286,7 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                         playerInventory[targetplayer.identifier][data.fromSlot] = {name = data.oldslotItem.name ,label = data.oldslotItem.label, weight = data.oldslotItem.weight, slot = data.fromSlot, count = data.oldslotItem.count, description = data.oldslotItem.description, metadata = data.oldslotItem.metadata, stackable = data.oldslotItem.stackable, closeonuse = ESXItems[data.oldslotItem.name].closeonuse}
                         playerInventory[Player.identifier][data.toSlot] = {name = data.newslotItem.name ,label = data.newslotItem.label, weight = data.newslotItem.weight, slot = data.toSlot, count = data.newslotItem.count, description = data.newslotItem.description, metadata = data.newslotItem.metadata, stackable = data.newslotItem.stackable, closeonuse = ESXItems[data.newslotItem.name].closeonuse}
                     else
-                        TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                        TriggerClientEvent("notification",src,"You can not carry this item",2)
                     end
                 end
             end
@@ -357,7 +358,7 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                     TriggerEvent("hsn-inventory:onAddInventoryItem",src,data.toItem.name,data.toItem.count)
                     TriggerEvent("hsn-inventory:onRemoveInventoryItem",src,data.fromItem.name,data.fromItem.count)
                 else
-                    TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                    TriggerClientEvent("notification",src,"You can not carry this item",2)
                 end
             elseif data.type == 'freeslot' then
                 if IfInventoryCanCarry(playerInventory[Player.identifier],ESX.GetConfig().MaxWeight, (data.item.weight * data.item.count))  then
@@ -365,14 +366,14 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                     playerInventory[Player.identifier][data.toslot] = {name = data.item.name ,label = data.item.label, weight = data.item.weight, slot = data.toslot, count = data.item.count, description = data.item.description, metadata = data.item.metadata, stackable = data.item.stackable, closeonuse = ESXItems[data.item.name].closeonuse}
                     TriggerEvent("hsn-inventory:onAddInventoryItem",src,data.item.name,data.item.count)
                 else
-                    TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                    TriggerClientEvent("notification",src,"You can not carry this item",2)
                 end
             elseif data.type == 'yarimswap' then
                 if IfInventoryCanCarry(playerInventory[Player.identifier],ESX.GetConfig().MaxWeight, (data.newslotItem.weight * data.newslotItem.count)) then
                     Drops[dropid].inventory[data.fromSlot] = {name = data.oldslotItem.name ,label = data.oldslotItem.label, weight = data.oldslotItem.weight, slot = data.fromSlot, count = data.oldslotItem.count, description = data.oldslotItem.description, metadata = data.oldslotItem.metadata, stackable = data.oldslotItem.stackable, closeonuse = ESXItems[data.oldslotItem.name].closeonuse}
                     playerInventory[Player.identifier][data.toSlot] = {name = data.newslotItem.name ,label = data.newslotItem.label, weight = data.newslotItem.weight, slot = data.toSlot, count = data.newslotItem.count, description = data.newslotItem.description, metadata = data.newslotItem.metadata, stackable = data.newslotItem.stackable, closeonuse = ESXItems[data.newslotItem.name].closeonuse}
                 else
-                    TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                    TriggerClientEvent("notification",src,"You can not carry this item",2)
                 end
             end
             if next(Drops[dropid].inventory) == nil then
@@ -424,7 +425,7 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                     TriggerEvent("hsn-inventory:onAddInventoryItem",src,data.toItem.name,data.toItem.count)
                     TriggerEvent("hsn-inventory:onRemoveInventoryItem",src,data.fromItem.name,data.fromItem.count)
                 else
-                    TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                    TriggerClientEvent("notification",src,"You can not carry this item",2)
                 end
             elseif data.type == 'freeslot' then
                 if  IfInventoryCanCarry(playerInventory[Player.identifier],ESX.GetConfig().MaxWeight, (data.item.weight * data.item.count))  then    
@@ -432,14 +433,14 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                     playerInventory[Player.identifier][data.toslot] = {name = data.item.name ,label = data.item.label, weight = data.item.weight, slot = data.toslot, count = data.item.count, description = data.item.description, metadata = data.item.metadata, stackable = data.item.stackable, closeonuse = ESXItems[data.item.name].closeonuse}
                     TriggerEvent("hsn-inventory:onAddInventoryItem",src,data.item.name,data.item.count)
                 else
-                    TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                    TriggerClientEvent("notification",src,"You can not carry this item",2)
                 end
             elseif data.type == 'yarimswap' then
                 if  IfInventoryCanCarry(playerInventory[Player.identifier],ESX.GetConfig().MaxWeight, (data.newslotItem.weight * data.newslotItem.count))  then    
                     Trunks[plate].inventory[data.fromSlot] = {name = data.oldslotItem.name ,label = data.oldslotItem.label, weight = data.oldslotItem.weight, slot = data.fromSlot, count = data.oldslotItem.count, description = data.oldslotItem.description, metadata = data.oldslotItem.metadata, stackable = data.oldslotItem.stackable, closeonuse = ESXItems[data.oldslotItem.name].closeonuse}
                     playerInventory[Player.identifier][data.toSlot] = {name = data.newslotItem.name ,label = data.newslotItem.label, weight = data.newslotItem.weight, slot = data.toSlot, count = data.newslotItem.count, description = data.newslotItem.description, metadata = data.newslotItem.metadata, stackable = data.newslotItem.stackable, closeonuse = ESXItems[data.newslotItem.name].closeonuse}
                 else
-                    TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                    TriggerClientEvent("notification",src,"You can not carry this item",2)
                 end
             end
         elseif data.frominv ~= data.toinv and (data.toinv == "glovebox" and data.frominv == "Playerinv") then
@@ -469,7 +470,7 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                     TriggerEvent("hsn-inventory:onAddInventoryItem",src,data.toItem.name,data.toItem.count)
                     TriggerEvent("hsn-inventory:onRemoveInventoryItem",src,data.fromItem.name,data.fromItem.count)
                 else
-                    TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                    TriggerClientEvent("notification",src,"You can not carry this item",2)
                 end
             elseif data.type == 'freeslot' then
                 TriggerEvent("hsn-inventory:onAddInventoryItem",src,data.item.name,data.item.count)
@@ -477,14 +478,14 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                     Gloveboxes[plate].inventory[data.emptyslot] = nil
                     playerInventory[Player.identifier][data.toslot] = {name = data.item.name ,label = data.item.label, weight = data.item.weight, slot = data.toslot, count = data.item.count, description = data.item.description, metadata = data.item.metadata, stackable = data.item.stackable, closeonuse = ESXItems[data.item.name].closeonuse}
                 else
-                    TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                    TriggerClientEvent("notification",src,"You can not carry this item",2)
                 end
             elseif data.type == 'yarimswap' then
                 if  IfInventoryCanCarry(playerInventory[Player.identifier],ESX.GetConfig().MaxWeight, (data.oldslotItem.weight * data.oldslotItem.count))  then    
                     Gloveboxes[plate].inventory[data.fromSlot] = {name = data.oldslotItem.name ,label = data.oldslotItem.label, weight = data.oldslotItem.weight, slot = data.fromSlot, count = data.oldslotItem.count, description = data.oldslotItem.description, metadata = data.oldslotItem.metadata, stackable = data.oldslotItem.stackable, closeonuse = ESXItems[data.oldslotItem.name].closeonuse}
                     playerInventory[Player.identifier][data.toSlot] = {name = data.newslotItem.name ,label = data.newslotItem.label, weight = data.newslotItem.weight, slot = data.toSlot, count = data.newslotItem.count, description = data.newslotItem.description, metadata = data.newslotItem.metadata, stackable = data.newslotItem.stackable, closeonuse = ESXItems[data.newslotItem.name].closeonuse}
                 else
-                    TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                    TriggerClientEvent("notification",src,"You can not carry this item",2)
                 end
             end
         elseif data.frominv ~= data.toinv and (data.toinv == "Playerinv" and data.frominv == 'stash') then
@@ -496,7 +497,7 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                     playerInventory[Player.identifier][data.toslot] = {name = data.toItem.name ,label = data.toItem.label, weight = data.toItem.weight, slot = data.toslot, count = data.toItem.count, description = data.toItem.description, metadata = data.toItem.metadata, stackable = data.toItem.stackable, closeonuse = ESXItems[data.toItem.name].closeonuse}
                     Stashs[stashId].inventory[data.fromslot] = {name = data.fromItem.name ,label = data.fromItem.label, weight = data.fromItem.weight, slot = data.fromslot, count = data.fromItem.count, description = data.fromItem.description, metadata = data.fromItem.metadata, stackable = data.fromItem.stackable, closeonuse = ESXItems[data.fromItem.name].closeonuse}
                 else
-                    TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                    TriggerClientEvent("notification",src,"You can not carry this item",2)
                 end
             elseif data.type == 'freeslot' then
                 if IfInventoryCanCarry(playerInventory[Player.identifier],ESX.GetConfig().MaxWeight, (data.item.weight * data.item.count)) then
@@ -504,19 +505,19 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                     playerInventory[Player.identifier][data.toslot] = {name = data.item.name ,label = data.item.label, weight = data.item.weight, slot = data.toslot, count = data.item.count, description = data.item.description, metadata = data.item.metadata, stackable = data.item.stackable, closeonuse = ESXItems[data.item.name].closeonuse}
                     TriggerEvent("hsn-inventory:onAddInventoryItem",src,data.item.name,data.item.count)
                 else
-                    TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                    TriggerClientEvent("notification",src,"You can not carry this item",2)
                 end
             elseif data.type == 'yarimswap' then
                 if IfInventoryCanCarry(playerInventory[Player.identifier],ESX.GetConfig().MaxWeight, (data.newslotItem.weight * data.newslotItem.count)) then
                     Stashs[stashId].inventory[data.fromSlot] = {name = data.oldslotItem.name ,label = data.oldslotItem.label, weight = data.oldslotItem.weight, slot = data.fromSlot, count = data.oldslotItem.count, description = data.oldslotItem.description, metadata = data.oldslotItem.metadata, stackable = data.oldslotItem.stackable, closeonuse = ESXItems[data.oldslotItem.name].closeonuse}
                     playerInventory[Player.identifier][data.toSlot] = {name = data.newslotItem.name ,label = data.newslotItem.label, weight = data.newslotItem.weight, slot = data.toSlot, count = data.newslotItem.count, description = data.newslotItem.description, metadata = data.newslotItem.metadata, stackable = data.newslotItem.stackable, closeonuse = ESXItems[data.newslotItem.name].closeonuse}
                 else
-                    TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                    TriggerClientEvent("notification",src,"You can not carry this item",2)
                 end
             end
         elseif data.frominv ~= data.toinv and (data.toinv == "Playerinv" and data.frominv == 'shop') then
             if data.type == 'swap' then
-                return TriggerClientEvent("notification",src,'You can not do this',2)
+                return TriggerClientEvent("notification",src,'You can not return your items',2)
             elseif data.type == 'freeslot' then
                 if IfInventoryCanCarry(playerInventory[Player.identifier],ESX.GetConfig().MaxWeight, (data.item.weight * data.item.count)) then
                     local money = Player.getMoney()
@@ -524,8 +525,8 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                         Player.removeMoney(data.item.price * data.item.count)
                         TriggerEvent("hsn-inventory:onAddInventoryItem",src,data.item.name,data.item.count)
                         if data.item.name:find('WEAPON_') then
-                            data.item.metadata = {}
-                            data.item.metadata.weaponlicense = GetRandomLicense()
+                            if not data.item.metadata then data.item.metadata = {} end
+                            data.item.metadata.weaponlicense = GetRandomLicense(data.item.metadata.weaponlicense)
                             data.item.metadata.ammo = 0
                             data.item.metadata.durability = 100
                         elseif data.item.name:find('identification') then
@@ -535,19 +536,19 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                             playerInventory[Player.identifier][data.toslot] = {name = data.item.name ,label = data.item.label, weight = data.item.weight, slot = data.toslot, count = data.item.count, description = data.item.description, metadata = data.item.metadata, stackable = data.item.stackable, closeonuse = ESXItems[data.item.name].closeonuse}
                             TriggerClientEvent("hsn-inventory:client:refreshInventory",src,playerInventory[Player.identifier])
                     else
-                        TriggerClientEvent("notification",src,'You dont have enough money '..data.item.price * data.item.count..'$',2)
+                        TriggerClientEvent("notification",src,'You can not afford this item ('..data.item.price * data.item.count..'$)',2)
                         TriggerClientEvent("hsn-inventory:client:refreshInventory",src,playerInventory[Player.identifier])
                     end
                 else
-                    TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                    TriggerClientEvent("notification",src,"You can not carry this item",2)
                 end
             elseif data.type == 'yarimswap' then
                 local money = Player.getMoney()
                 if IfInventoryCanCarry(playerInventory[Player.identifier],ESX.GetConfig().MaxWeight, (data.newslotItem.weight * data.newslotItem.count)) then
                     if (money >= (data.newslotItem.price *  data.newslotItem.count)) then
                         if data.newslotItem.name:find('WEAPON_') then
-                            data.newslotItem.metadata = {}
-                            data.newslotItem.metadata.weaponlicense = GetRandomLicense()
+                            if not data.newslotItem.metadata then data.newslotItem.metadata = {} end
+                            data.newslotItem.metadata.weaponlicense = GetRandomLicense(data.newslotItem.metadata.weaponlicense)
                             data.newslotItem.metadata.ammo = 0
                             data.newslotItem.metadata.durability = 100
                         elseif data.newslotItem.name:find('identification') then
@@ -560,15 +561,15 @@ AddEventHandler("hsn-inventory:server:saveInventoryData",function(data)
                     else
                         Citizen.Wait(5)
                         TriggerClientEvent("hsn-inventory:client:refreshInventory",src,playerInventory[Player.identifier])
-                        TriggerClientEvent("notification",src,'You dont have enough money '..data.newslotItem.price *  data.newslotItem.count..'$',2)
+                        TriggerClientEvent("notification",src,'You can not afford this item ('..data.newslotItem.price *  data.newslotItem.count..'$)',2)
                     end
                 else
-                    TriggerClientEvent("notification",src,'You can not carry any more item',2)
+                    TriggerClientEvent("notification",src,"You can not carry this item",2)
                 end
             end
         elseif data.frominv ~= data.toinv and (data.toinv == "shop" and data.frominv == 'Playerinv') then
             TriggerClientEvent("hsn-inventory:client:refreshInventory",src,playerInventory[Player.identifier])
-            return TriggerClientEvent("notification",src,'You can not do this',2)
+            return TriggerClientEvent("notification",src,'You can not return your items',2)
         end
     end
 end)
@@ -679,7 +680,7 @@ AddEventHandler("hsn-inventory:server:openStash",function(stash)
     if checkOpenable(src,stash.name) then
         TriggerClientEvent("hsn-inventory:client:openInventory",src,playerInventory[Player.identifier], Stashs[stash.name])
     else
-        TriggerClientEvent("notification",src,'You can\'t open this inventory',2)
+        TriggerClientEvent("notification",src,'You can not open this inventory',2)
     end
 end)
 
@@ -886,7 +887,7 @@ AddEventHandler("hsn-inventory:server:useItem",function(item,slot)
         else
             if ESX.UsableItemsCallbacks[item.name] ~= nil then
                 TriggerClientEvent("hsn-inventory:client:esxUseItem",src,item)
-                TriggerClientEvent("hsn-inventory:client:addItemNotify",source,ESXItems[item.name],'Used 1x')
+                --TriggerClientEvent("hsn-inventory:client:addItemNotify",source,ESXItems[item.name],'Used 1x')
             end
         end
     end
@@ -911,7 +912,7 @@ AddEventHandler("hsn-inventory:server:useItemfromSlot",function(slot)
                 end
             else
                 TriggerClientEvent("hsn-inventory:client:esxUseItem",src,playerInventory[Player.identifier][slot])
-                TriggerClientEvent("hsn-inventory:client:addItemNotify",source,ESXItems[playerInventory[Player.identifier][slot].name],'Used 1x')
+                --TriggerClientEvent("hsn-inventory:client:addItemNotify",source,ESXItems[playerInventory[Player.identifier][slot].name],'Used 1x')
             end
         end
     end

--- a/server.lua
+++ b/server.lua
@@ -27,11 +27,7 @@ exports.ghmattimysql:ready(function()
     end)
     print('[^2hsn-inventory^0] - Started!')
     print('[^2hsn-inventory^0] - Items are created!')
-    print('^1[hsn-inventory] - Don\'t restart this script while players in game !')
 end)
-
-
-
 
 IfInventoryCanCarry = function(inventory, maxweight, newWeight)
     newWeight = tonumber(newWeight)
@@ -1138,13 +1134,40 @@ AddEventHandler("hsn-inventory:setplayerInventory",function(identifier,inventory
     end
 end)
 
-AddEventHandler('onResourceStart', function(resourceName)
+AddEventHandler('onResourceStop', function(resourceName)
     if (GetCurrentResourceName() == resourceName) then
         local Players = ESX.GetPlayers()
-       -- print(#Players)
+        for k,v in pairs(Players) do
+            local Player = ESX.GetPlayerFromId(v)
+            local inventory = {}
+            inventory = json.encode(GetInventory(playerInventory[Player.identifier]))
+                exports.ghmattimysql:execute('UPDATE users SET inventory = @inventory WHERE identifier = @identifier', {
+                    ['@inventory'] = inventory,
+                    ['@identifier'] = Player.identifier
+                })
+        end
+    end
+end)
+
+AddEventHandler('onResourceStart', function(resourceName)
+    if (GetCurrentResourceName() == resourceName) then
+        Citizen.Wait(100)
+        local Players = ESX.GetPlayers()
         for k,v in pairs(Players) do
             local Player = ESX.GetPlayerFromId(v)
             playerInventory[Player.identifier] = {}
+            exports.ghmattimysql:ready(function()
+                exports.ghmattimysql:execute('SELECT inventory FROM users WHERE identifier = @identifier', {
+                    ['@identifier'] = Player.identifier
+                }, function(result)
+                    local inventory = {}
+                    if result[1].inventory and result[1].inventory ~= '' then
+                        inventory = json.decode(result[1].inventory)
+                    end
+                    TriggerEvent('hsn-inventory:setplayerInventory', Player.identifier, inventory)
+                end)
+            end)
+
         end
     end
 end)


### PR DESCRIPTION
`onResourceStart` load inventory data for active players
`onResourceStop` save inventory data for active players
Display `metadata.description` if it is defined
Add support for player identification card
Adjust weapon serial numbers (set its default `weaponlicense = 'POL'` and it will display 123456POL123456)
Centered the inventory properly
Changed some stuff with notifications
Add support for walking and using voice chat while in inventory (cannot walk if accessing a secondary inventory)
Job restricted shops (police armoury)
Command to close inventory (just in case)
