### PR TITLE
Read comment

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -490,13 +490,15 @@ RegisterCommand('closeinv', function()
 end, false)
 
 
-
 RegisterNetEvent("hsn-inventory:useItem")
 AddEventHandler("hsn-inventory:useItem",function(item)
     if item.name then item = item.name end
     data = Config.ItemList[item]
     data.item = item
     if data.closeInv then TriggerEvent("hsn-inventory:client:closeInventory") end
+    if data.item == 'lockpick' then
+        TriggerEvent('esx_lockpick:onUse')
+    end
     if data.animDict then
         exports['mythic_progbar']:Progress({
             name = "useitem",
@@ -504,7 +506,7 @@ AddEventHandler("hsn-inventory:useItem",function(item)
             label = "Using "..data.item,
             useWhileDead = false,
             canCancel = false,
-            controlDisables = { disableMovement = false, disableCarMovement = false, disableMouse = false, disableCombat = true },
+            controlDisables = { disableMovement = data.disableMove, disableCarMovement = false, disableMouse = false, disableCombat = true },
             animation = { animDict = data.animDict, anim = data.anim, flags = 49 },
             prop = { model = data.model, coords = data.coords, rotation = data.rotation }
         }, function()
@@ -517,7 +519,7 @@ AddEventHandler("hsn-inventory:useItem",function(item)
             label = "Using "..data.item,
             useWhileDead = false,
             canCancel = false,
-            controlDisables = { disableMovement = false, disableCarMovement = false, disableMouse = false, disableCombat = true },
+            controlDisables = { disableMovement = data.disableMove, disableCarMovement = false, disableMouse = false, disableCombat = true },
             animation = { animDict = 'pickup_object', anim = 'putdown_low', flags = 48 },
             prop = nil,
         }, function()
@@ -536,9 +538,6 @@ function itemUsed(data)
         if data.thirst > 0 then TriggerEvent('esx_status:add', 'thirst', data.thirst)
         else TriggerEvent('esx_status:remove', 'thirst', data.thirst) end
     end
-    --TriggerServerEvent('esx:removeInventoryItem', 'item_standard', data.item, 1)
-    if data.consume then TriggerServerEvent('hsn-inventory:server:removeItem', data.item, data.consume) end
-
 
     if data.item == 'bandage' then
         local maxHealth = 200
@@ -549,5 +548,6 @@ function itemUsed(data)
 		TriggerEvent('mythic_hospital:client:ReduceBleed')
     end
 
-
+    
+    if data.consume then TriggerServerEvent('hsn-inventory:server:removeItem', data.item, data.consume) end
 end

--- a/client.lua
+++ b/client.lua
@@ -556,5 +556,5 @@ function itemUsed(data)
     end
 
     
-    if data.consume then TriggerServerEvent('hsn-inventory:server:removeItem', data.item, data.consume) end
+    if data.consume then TriggerServerEvent('hsn-inventory:client:removeItem', data.item, data.consume) end
 end

--- a/client.lua
+++ b/client.lua
@@ -68,7 +68,7 @@ Citizen.CreateThread(function()
     end
 end)
 
-RegisterCommand('trunkinv', function()
+RegisterCommand('vehinv', function()
     local playerPed = PlayerPedId()
     if not isDead and not isCuffed and not IsPedInAnyVehicle(playerPed, false) then
         local vehicle = ESX.Game.GetClosestVehicle()
@@ -82,24 +82,16 @@ RegisterCommand('trunkinv', function()
                 TriggerEvent('notification','Car locked',2)
             end
         end
-    end
-end,false)
-
-RegisterCommand('glovebox', function()
-    if IsPedInAnyVehicle(PlayerPedId(), false) then
-        local playerPed = PlayerPedId()
-    
-        if not isDead and not isCuffed and IsPedInAnyVehicle(playerPed, false) then -- [G]lovebox
-            local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
-            local plate = GetVehicleNumberPlateText(vehicle)
-            OpenGloveBox(plate)
-        end
+    elseif not isDead and not isCuffed and IsPedInAnyVehicle(playerPed, false) then -- [G]lovebox
+        local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
+        local plate = GetVehicleNumberPlateText(vehicle)
+        OpenGloveBox(plate)
     end
 end,false)
     
 RegisterCommand('inventory', function()
     local playerPed = PlayerPedId()
-    if not isDead and not isCuffed then
+    if not isDead and not isCuffed and not invOpen then
         TriggerEvent("randPickupAnim")
         TriggerServerEvent("hsn-inventory:server:openInventory",{type = 'drop',id = currentDrop})
         TriggerServerEvent('inventory:isShopOpen', false)
@@ -107,8 +99,7 @@ RegisterCommand('inventory', function()
 end, false)
         
 RegisterKeyMapping('inventory', 'Inv: Inventory Open', 'keyboard', 'F2')
-RegisterKeyMapping('trunkinv', 'Inv: Trunk Inventory', 'keyboard', 'F3')
-RegisterKeyMapping('glovebox', 'Inv: Glovebox Inventory', 'keyboard', 'F3')
+RegisterKeyMapping('vehinv', 'Inv: Vehicle Inventory', 'keyboard', 'F3')
 
 OpenGloveBox = function(gloveboxid)
     TriggerServerEvent("hsn-inventory:server:openInventory",{type = 'glovebox',id = 'glovebox-'..gloveboxid})
@@ -202,6 +193,7 @@ AddEventHandler("hsn-inventory:client:addItemNotify",function(item,text)
         item = item,
         text = text
     })
+    ExecuteCommand('fixinv')
 end)
 
 

--- a/client.lua
+++ b/client.lua
@@ -388,7 +388,7 @@ AddEventHandler("hsn-inventory:addAmmo",function(item, name)
                 SetPedAmmo(playerPed, weapon, newAmmo)
                 TriggerEvent("notification","Reloaded")
                 TriggerServerEvent("hsn-inventory:client:removeItem",name,1)		
-                TriggerEvent("notification","Max Ammo")
+            else TriggerEvent("notification","Max Ammo")
             end
         end
     end

--- a/client.lua
+++ b/client.lua
@@ -1,24 +1,50 @@
 ESX = nil
 local PlayerData = {}
+local invOpen, isDead, isCuffed = false, false, false
 -- hsn inventory Hasan.#7803
 Citizen.CreateThread(function()
     while ESX == nil do
         TriggerEvent('esx:getSharedObject', function(obj)
             ESX = obj
         end)
-        Citizen.Wait(0)
+        Citizen.Wait(10)
     end
     while ESX.GetPlayerData().job == nil do
         Citizen.Wait(10)
     end
     PlayerData = ESX.GetPlayerData()
 end)
+
+RegisterNetEvent('esx:setJob')
+AddEventHandler('esx:setJob', function(job)
+    PlayerData.job = job
+end)
+
 local Drops = {}
 local currentDrop = nil
 local curweaponSlot = nil
 local keys = {
     157, 158, 160, 164, 165
 }
+
+AddEventHandler('esx:onPlayerDeath', function(data)
+	isDead = true
+end)
+
+AddEventHandler('esx:onPlayerSpawn', function(spawn)
+	isDead = false
+end)
+
+RegisterNetEvent('esx_policejob:handcuff')
+AddEventHandler('esx_policejob:handcuff', function()
+	isCuffed = not isCuffed
+end)
+
+RegisterNetEvent('esx_policejob:unrestrain')
+AddEventHandler('esx_policejob:unrestrain', function()
+	isCuffed = false
+end)
+
 Citizen.CreateThread(function()
     while true do
         Citizen.Wait(3)
@@ -32,20 +58,19 @@ Citizen.CreateThread(function()
         DisableControlAction(0, 164, true) -- 4
         DisableControlAction(0, 165, true) -- 5
         DisableControlAction(0, 289, true) -- F2
-        
-        for k, v in pairs(keys) do
-            local playerPed = PlayerPedId()
-            if IsDisabledControlJustReleased(0, v) then
-                TriggerServerEvent("hsn-inventory:server:useItemfromSlot",k)
+        if not invOpen then
+            for k, v in pairs(keys) do
+                if IsDisabledControlJustReleased(0, v) and not dead and not isCuffed then
+                    TriggerServerEvent("hsn-inventory:server:useItemfromSlot",k)
+                end
             end
         end
     end
 end)
 
-
 RegisterCommand('trunkinv', function()
     local playerPed = PlayerPedId()
-    if not IsPedInAnyVehicle(playerPed, false) then
+    if not isDead and not isCuffed and not IsPedInAnyVehicle(playerPed, false) then
         local vehicle = ESX.Game.GetClosestVehicle()
         local pos = GetEntityCoords(PlayerPedId())
         local trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0, -2.5, 0)
@@ -64,7 +89,7 @@ RegisterCommand('glovebox', function()
     if IsPedInAnyVehicle(PlayerPedId(), false) then
         local playerPed = PlayerPedId()
     
-        if IsPedInAnyVehicle(playerPed, false) then -- [G]lovebox
+        if not isDead and not isCuffed and IsPedInAnyVehicle(playerPed, false) then -- [G]lovebox
             local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
             local plate = GetVehicleNumberPlateText(vehicle)
             OpenGloveBox(plate)
@@ -73,9 +98,12 @@ RegisterCommand('glovebox', function()
 end,false)
     
 RegisterCommand('inventory', function()
-    TriggerEvent("randPickupAnim")
-    TriggerServerEvent("hsn-inventory:server:openInventory",{type = 'drop',id = currentDrop})
-    TriggerServerEvent('inventory:isShopOpen', false)
+    local playerPed = PlayerPedId()
+    if not isDead and not isCuffed then
+        TriggerEvent("randPickupAnim")
+        TriggerServerEvent("hsn-inventory:server:openInventory",{type = 'drop',id = currentDrop})
+        TriggerServerEvent('inventory:isShopOpen', false)
+    end
 end,false)
         
 RegisterKeyMapping('inventory', 'Inv: Inventory Open', 'keyboard', 'F2')
@@ -92,55 +120,58 @@ OpenTrunk = function(trunkid)
 end
 RegisterNetEvent("hsn-inventory:client:openInventory")
 AddEventHandler("hsn-inventory:client:openInventory",function(inventory,other)
+    invOpen = true
     -- some players dupe while taskbar on screen
     -- local check = exports["progressBars"]:onScreen()
     -- if check then
     --     return
     -- end
-    
     local playerID = GetPlayerServerId(PlayerId())
     SendNUIMessage({
         message = 'openinventory',
         inventory = inventory,
         slots = Config.PlayerSlot,
-        name = GetPlayerName(PlayerId()).. '[' .. playerID ..']',
+        name = GetPlayerName(PlayerId())..' ['.. playerID ..']',
         maxweight = ESX.GetConfig().MaxWeight,
         rightinventory = other
     })
     TriggerServerEvent("hsn-inventory:setcurrentInventory",other)
-    SetNuiFocus(true, true)
+    if other == nil then movement = true else movement = false end
+    SetNuiFocusAdvanced(true, true, movement)
 end)
 
 
 
 RegisterNetEvent("hsn-inventory:client:closeInventory")
 AddEventHandler("hsn-inventory:client:closeInventory",function(id)
+    invOpen = false
     SendNUIMessage({
         message = 'close',
     })
-    SetNuiFocus(false,false)
+    SetNuiFocusAdvanced(false,false)
     TriggerServerEvent("hsn-inventory:removecurrentInventory",id)
     TriggerServerEvent('inventory:isShopOpen', false)
 end)
 
---[[ RegisterCommand("teststash",function()
+--[[RegisterCommand("teststash",function()
      TriggerServerEvent("hsn-inventory:server:openStash", {name = 'Hasqaws',slots = 15, type = 'stash'})
- end)
-]]
+end)]]
+
 RegisterNetEvent("hsn-inventory:client:refreshInventory")
 AddEventHandler("hsn-inventory:client:refreshInventory",function(inventory)
+    local playerID = GetPlayerServerId(PlayerId())
     SendNUIMessage({
         message = 'refresh',
         inventory = inventory,
         slots = Config.PlayerSlot,
-        name = GetPlayerName(PlayerId())..' ['..GetPlayerServerId()..']',
+        name = GetPlayerName(PlayerId())..' ['.. playerID ..']',
         maxweight = ESX.GetConfig().MaxWeight,
     })
 end)
 
 
 RegisterNUICallback("exit",function(data)
-    SetNuiFocus(false,false)
+    SetNuiFocusAdvanced(false,false)
     TriggerServerEvent('hsn-inventory:server:saveInventory',data)
     TriggerServerEvent("hsn-inventory:removecurrentInventory",data.invid)
 end)
@@ -192,34 +223,41 @@ end
 
 Citizen.CreateThread(function()
     while true do
-        Citizen.Wait(2)
+        while not PlayerData.job do Citizen.Wait(0) end
+        local wait = 100
         for i = 1, #Config.Shops do
             distance = #(GetEntityCoords(PlayerPedId()) - Config.Shops[i].coords)
-            if distance <= 2.5 then
-                DrawText3Ds(Config.Shops[i].coords.x,Config.Shops[i].coords.y,Config.Shops[i].coords.z+0.3,Config.Shops[i].text)
-                DrawMarker(2, Config.Shops[i].coords.x,Config.Shops[i].coords.y,Config.Shops[i].coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 200, 0, 0, 222, false, false, false, true, false, false, false)
-                local playerPed = PlayerPedId()
-                if IsControlJustPressed(1,38) then
+            if distance <= 2.5 and (not Config.Shops[i].job or Config.Shops[i].job == PlayerData.job.name) then
+                DrawMarker(2, Config.Shops[i].coords.x,Config.Shops[i].coords.y,Config.Shops[i].coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.15, 0.2, 30, 150, 30, 100, false, false, false, true, false, false, false)
+                if IsControlJustPressed(1,38) and distance <= 2 and not dead and not isCuffed then
                     OpenShop(Config.Shops[i])
                 end
+                wait = 2
             end
         end
+        Citizen.Wait(wait)
     end
 end)
 
 Citizen.CreateThread(function()
+    while not PlayerData.job do Citizen.Wait(0) end
     for k,v in pairs(Config.Shops) do
-        local blip = AddBlipForCoord(v.coords.x, v.coords.y, v.coords.z)
-        SetBlipSprite(blip, v.blip.id or 1)
-        SetBlipDisplay(blip, 4)
-        SetBlipScale(blip, v.blip.scale or 0.5)
-        SetBlipColour(blip, v.blip.color or 1)
-        SetBlipAsShortRange(blip, true)
-        BeginTextCommandSetBlipName("STRING")
-        AddTextComponentString(v.blip.name or 'Shop')
-        EndTextCommandSetBlipName(blip)
+        if (not Config.Shops[k].job or Config.Shops[k].job == PlayerData.job.name) then
+            local blip = AddBlipForCoord(v.coords.x, v.coords.y, v.coords.z)
+            SetBlipSprite(blip, v.blip.id or 1)
+            SetBlipDisplay(blip, 4)
+            SetBlipScale(blip, v.blip.scale or 0.5)
+            SetBlipColour(blip, v.blip.color or 1)
+            SetBlipAsShortRange(blip, true)
+            BeginTextCommandSetBlipName("STRING")
+            AddTextComponentString(v.blip.name or 'Shop')
+            EndTextCommandSetBlipName(blip)
+        end
     end
 end)
+
+
+
 
 OpenShop = function(id)
     TriggerServerEvent("hsn-inventory:server:openInventory",{type = 'shop',id = id})
@@ -261,6 +299,7 @@ AddEventHandler('randPickupAnim', function()
     ClearPedSecondaryTask(PlayerPedId())
 end)
 
+
 RegisterNetEvent("hsn-inventory:client:removeDrop")
 AddEventHandler("hsn-inventory:client:removeDrop",function(dropid)
     Drops[dropid] = nil
@@ -280,12 +319,10 @@ RegisterNUICallback("UseItem", function(data, cb)
     if data.inv ~= "Playerinv" then
         return
     end
-
-    TriggerServerEvent("hsn-inventory:server:useItem",data.item)
-    
     if shouldCloseInventory(data.item.name) then
         TriggerEvent("hsn-inventory:client:closeInventory")
     end
+    TriggerServerEvent("hsn-inventory:server:useItem",data.item)
 end)
 
 RegisterNUICallback("saveinventorydata",function(data)
@@ -328,8 +365,15 @@ AddEventHandler("hsn-inventory:client:weapon",function(item)
         curweaponSlot = item.slot
         GiveWeaponToPed(PlayerPedId(), GetHashKey(item.name), item.metadata.ammo, false, false)
         SetCurrentPedWeapon(PlayerPedId(), GetHashKey(item.name), true)
+        local str = item.metadata.weaponlicense
+        if str:find('POL') then
+            SetPedWeaponTintIndex(PlayerPedId(), item.name, 5)
+            if item.name:find('PISTOL') then component = GetHashKey('COMPONENT_AT_PI_FLSH') end
+            if component then GiveWeaponComponentToPed(PlayerPedId(), GetHashKey(item.name), component) end
+        end
         SetPedAmmo(PlayerPedId(), GetHashKey(item.name), item.metadata.ammo)
     end
+    TriggerEvent('hsn-inventory:currentWeapon', item) -- using for another resource
 end)
 
 RegisterNetEvent("hsn-inventory:addAmmo")
@@ -350,7 +394,7 @@ AddEventHandler("hsn-inventory:addAmmo",function(item, name)
             ClearPedTasks(playerPed)
             local found, maxAmmo = GetMaxAmmo(playerPed, weapon)
             if newAmmo < maxAmmo then
-		TriggerServerEvent("hsn-inventory:server:addweaponAmmo",curweaponSlot,item.count)
+                TriggerServerEvent("hsn-inventory:server:addweaponAmmo",curweaponSlot,item.count)
                 TaskReloadWeapon(playerPed)
                 SetPedAmmo(playerPed, weapon, newAmmo)
                 TriggerEvent("notification","Reloaded")
@@ -384,12 +428,12 @@ end)
 
 RegisterNetEvent("hsn-inventory:client:esxUseItem")
 AddEventHandler("hsn-inventory:client:esxUseItem",function(item)
-    TriggerServerEvent("esx:useItem",item)
+    TriggerServerEvent("esx:useItem", item.name)
 end)
 
 RegisterCommand("steal",function()
     local ped = PlayerPedId()
-	if not IsEntityPlayingAnim(ped, 'dead', 'dead_a', 3) and not IsPedInAnyVehicle(ped, true) then	 
+	if not IsPedInAnyVehicle(ped, true) and not isDead and not isCuffed then	 
 		rob()
 	end
 end)
@@ -400,14 +444,16 @@ function rob()
         local target, distance = ESX.Game.GetClosestPlayer()
         local searchPlayerPed = GetPlayerPed(target)
 
-        if IsEntityPlayingAnim(searchPlayerPed, 'random@mugging3', 'handsup_standing_base', 3) or IsEntityPlayingAnim(searchPlayerPed, 'missminuteman_1ig_2', 'handsup_base', 3) or IsEntityPlayingAnim(searchPlayerPed, 'dead', 'dead_a', 3) then
+        if IsEntityPlayingAnim(searchPlayerPed, 'random@mugging3', 'handsup_standing_base', 3) or IsEntityPlayingAnim(searchPlayerPed, 'missminuteman_1ig_2', 'handsup_base', 3) then
             TriggerServerEvent("hsn-inventory:server:robPlayer",GetPlayerServerId(closestPlayer))
         else
         end
     else
-        TriggerEvent("notification",'No one is nearby')
+        TriggerEvent("notification",'There is nobody nearby')
     end
 end
+
+
 
 Citizen.CreateThread(function()
     while true do
@@ -420,4 +466,109 @@ Citizen.CreateThread(function()
     end
 end)
 
+local nui_focus = {false, false}
+function SetNuiFocusAdvanced(hasFocus, hasCursor, allowMovement)
+    SetNuiFocus(hasFocus, hasCursor)
+    SetNuiFocusKeepInput(hasFocus)
+    nui_focus = {hasFocus, hasCursor}
+    TriggerEvent("nui:focus", hasFocus, hasCursor)
 
+    if nui_focus[1] then
+        Citizen.CreateThread(function()
+            local ticks = 0
+            while true do
+                Citizen.Wait(0)
+                DisableAllControlActions(0)
+                if not nui_focus[2] then
+                    EnableControlAction(0, 1, true)
+                    EnableControlAction(0, 2, true)
+                end
+                EnableControlAction(0, 249, true) -- N for PTT
+                EnableControlAction(0, 20, true) -- Z for proximity
+                if allowMovement then
+                    EnableControlAction(0, 30, true) -- movement
+                    EnableControlAction(0, 31, true) -- movement
+                end
+                if not nui_focus[1] then
+                    ticks = ticks + 1
+                    if (IsDisabledControlJustReleased(0, 200, true) or ticks > 20) then
+                        invOpen = false
+                        break
+                    end
+                end
+            end
+        end)
+    end
+end
+
+RegisterNetEvent("notification")
+AddEventHandler("notification",function(message, mtype)
+    if mtype == 1 then mtype = { ['background-color'] = 'rgba(55,55,175)', ['color'] = 'white' }
+    elseif not mtype or mtype == 2 then mtype = { ['background-color'] = 'rgba(175,55,55)', ['color'] = 'white' }
+    end
+    TriggerEvent('mythic_notify:client:SendAlert', {type = 'inform', text = message, length = 2500,style = mtype})
+end)
+
+RegisterCommand('closeinv', function()
+        TriggerEvent("hsn-inventory:client:closeInventory")
+end, false)
+
+
+
+RegisterNetEvent("hsn-inventory:useItem")
+AddEventHandler("hsn-inventory:useItem",function(data, label)
+    data = Config.ItemList[data]
+    if data.animDict then
+        exports['mythic_progbar']:Progress({
+            name = "useitem",
+            duration = data.useTime,
+            label = "Using "..label,
+            useWhileDead = false,
+            canCancel = false,
+            controlDisables = { disableMovement = false, disableCarMovement = false, disableMouse = false, disableCombat = true },
+            animation = { animDict = data.animDict, anim = data.anim, flags = 49 },
+            prop = { model = data.model, coords = data.coords, rotation = data.rotation }
+        }, function()
+            itemUsed(data)
+        end)
+    else
+        exports['mythic_progbar']:Progress({
+            name = "useitem",
+            duration = data.useTime,
+            label = "Using "..label,
+            useWhileDead = false,
+            canCancel = false,
+            controlDisables = { disableMovement = false, disableCarMovement = false, disableMouse = false, disableCombat = true },
+            animation = { animDict = 'pickup_object', anim = 'putdown_low', flags = 48 },
+            prop = nil,
+        }, function()
+            itemUsed(data)
+        end)
+    end
+
+end)
+
+function itemUsed(data)
+    if data.hunger then
+        if data.hunger > 0 then TriggerEvent('esx_status:add', 'hunger', data.hunger)
+        else TriggerEvent('esx_status:remove', 'hunger', data.hunger) end
+    end
+    if data.thirst then
+        if data.thirst > 0 then TriggerEvent('esx_status:add', 'thirst', data.thirst)
+        else TriggerEvent('esx_status:remove', 'thirst', data.thirst) end
+    end
+    --TriggerServerEvent('esx:removeInventoryItem', 'item_standard', data.item, 1)
+    if data.consume and data.consume > 0 then TriggerServerEvent('hsn-inventory:server:removeItem', data.item, data.consume) end
+
+
+    if data.item == 'bandage' then
+        local maxHealth = 200
+		local health = GetEntityHealth(PlayerPedId())
+		local newHealth = math.min(maxHealth, math.floor(health + maxHealth / 16))
+        SetEntityHealth(PlayerPedId(), newHealth)
+		TriggerEvent('mythic_hospital:client:FieldTreatBleed')
+		TriggerEvent('mythic_hospital:client:ReduceBleed')
+    end
+
+
+end

--- a/config.lua
+++ b/config.lua
@@ -58,27 +58,6 @@ Config.DurabilityDecraseAmount = {
     ['WEAPON_WRENCH'] = 1.0,
 }
 
-Config.CloseUiItems = {
-    "WEAPON_KNUCKLE",
-	"WEAPON_FLASHBANG",
-	"WEAPON_DBSHOTGUN",
-	"WEAPON_MACHINEPISTOL", 
-	"WEAPON_GUSENBERG", 
-	"WEAPON_ASSUALTRIFLE",
-	"WEAPON_MINISMG", 
-	"WEAPON_MICROSMG", 
-	"WEAPON_ADVANCEDRIFLE",
-	"WEAPON_VINTAGEPISTOL", 
-	"WEAPON_COMBATPDW", 
-	"WEAPON_COMPACTRIFLE", 
-	"WEAPON_BULLPUPSHOTGUN", 
-	"WEAPON_HEAVYPISTOL", 
-	"WEAPON_PISTOL50", 
-	"WEAPON_SAWNOFFSHOTGUN", 
-	"WEAPON_CARBINERIFLE_MK2",
-	"WEAPON_SG_PUMPSHOTGUN"
-}
-
 Config.Shops = {
     { -- 24/7
         coords = vector3(-531.14, -1221.33, 17.48),
@@ -2359,7 +2338,7 @@ Config.Ammos = {
 
 Config.ItemList = {
 
-    {   item = 'burger',
+    ['burger'] = {
         thirst = 0,
         hunger = 200000,
         animDict = "mp_player_inteat@burger",
@@ -2368,11 +2347,12 @@ Config.ItemList = {
         coords = { x = 0.02, y = 0.022, z = -0.02 },
         rotation = { x = 0.0, y = 5.0, z = 0.0 },
         useTime = 2500,
-        consume = 1
+        consume = 1,
+        closeInv = 1
 
     },
 
-    {   item = 'water',
+    ['water'] = {
         thirst = 200000,
         hunger = 0,
         animDict = "mp_player_intdrink",
@@ -2381,10 +2361,11 @@ Config.ItemList = {
         coords = { x = 0.03, y = 0.0, z = 0.02 },
         rotation = { x = 0.0, y = -13.5, z = -1.5 },
         useTime = 2500,
-        consume = 1
+        consume = 1,
+        closeInv = 1
     },
 
-    {   item = 'bandage',
+    ['bandage'] = {
         animDict = "missheistdockssetup1clipboard@idle_a",
         anim = "idle_a",
         flags = 49,
@@ -2392,10 +2373,11 @@ Config.ItemList = {
         coords = { x = -0.14, y = 0.02, z = -0.08 },
         rotation = { x = -50.0, y = -50.0, z = 0.0 },
         useTime = 2500,
-        consume = 1
+        consume = 1,
+        closeInv = 1
     },
 
-    {   item = 'identification',
+    ['identification'] = {   
         useTime = 0,
         consume = 0
     },

--- a/config.lua
+++ b/config.lua
@@ -63,12 +63,11 @@ Config.Shops = {
         coords = vector3(-531.14, -1221.33, 17.48),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop', 
+        name = 'Xero Gas', 
         inventory = {
             {
                 name = 'sandwich',
@@ -121,12 +120,11 @@ Config.Shops = {
         coords = vector3(2557.458,  382.282, 107.622),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop2', 
+        name = '24/7', 
         inventory = {
             {
                 name = 'sandwich',
@@ -179,12 +177,11 @@ Config.Shops = {
         coords = vector3(-3038.939, 585.954, 6.908),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop3', 
+        name = '24/7', 
         inventory = {
             {
                 name = 'sandwich',
@@ -237,12 +234,11 @@ Config.Shops = {
         coords = vector3(-3241.927, 1001.462, 11.830),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop4', 
+        name = '24/7', 
         inventory = {
             {
                 name = 'sandwich',
@@ -295,12 +291,11 @@ Config.Shops = {
         coords = vector3(547.431, 2671.710, 41.156),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop5', 
+        name = '24/7', 
         inventory = {
             {
                 name = 'sandwich',
@@ -353,12 +348,11 @@ Config.Shops = {
         coords = vector3(1961.464, 3740.672, 31.343),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop6', 
+        name = '24/7', 
         inventory = {
             {
                 name = 'sandwich',
@@ -411,12 +405,11 @@ Config.Shops = {
         coords = vector3(2678.916, 3280.671, 54.241),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop7', 
+        name = '24/7', 
         inventory = {
             {
                 name = 'sandwich',
@@ -469,12 +462,11 @@ Config.Shops = {
         coords = vector3(1729.216, 6414.131, 34.037),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop8', 
+        name = '24/7', 
         inventory = {
             {
                 name = 'sandwich',
@@ -527,12 +519,11 @@ Config.Shops = {
         coords = vector3(-48.519, -1757.514, 28.421),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop9', 
+        name = 'Davis LTD', 
         inventory = {
             {
                 name = 'sandwich',
@@ -585,12 +576,11 @@ Config.Shops = {
         coords = vector3(1163.373, -323.801, 68.205),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop10', 
+        name = 'Mirror Park LTD', 
         inventory = {
             {
                 name = 'sandwich',
@@ -643,12 +633,11 @@ Config.Shops = {
         coords = vector3(-707.501, -914.260, 18.215),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop11', 
+        name = 'Little Seoul LTD', 
         inventory = {
             {
                 name = 'sandwich',
@@ -701,12 +690,11 @@ Config.Shops = {
         coords = vector3(-1820.523, 792.518, 137.118),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop12', 
+        name = 'Richman Glen LTD', 
         inventory = {
             {
                 name = 'sandwich',
@@ -759,12 +747,11 @@ Config.Shops = {
         coords = vector3(1698.388, 4924.404, 41.063),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop13', 
+        name = 'Grapeseed LTD', 
         inventory = {
             {
                 name = 'sandwich',
@@ -817,12 +804,11 @@ Config.Shops = {
         coords = vector3(25.723, -1346.966, 28.497),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop14', 
+        name = '24/7', 
         inventory = {
             {
                 name = 'sandwich',
@@ -875,12 +861,11 @@ Config.Shops = {
         coords = vector3(373.875, 325.896, 102.566),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop15', 
+        name = '24/7', 
         inventory = {
             {
                 name = 'sandwich',
@@ -930,15 +915,14 @@ Config.Shops = {
         },
     },
     {
-        coords = vector3(-2540.88, 2314.22, 32.42),
+        coords = vector3(-2544.092, 2316.184, 33.2),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop16', 
+        name = 'Lago Zancudo RON', 
         inventory = {
             {
                 name = 'sandwich',
@@ -991,12 +975,11 @@ Config.Shops = {
         coords = vector3(161.27, 6640.28, 30.72),
         blip = {
             id = 52,
-            name = "Shop",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop17', 
+        name = "Don's Country Store", 
         inventory = {
             {
                 name = 'sandwich',
@@ -1055,7 +1038,7 @@ Config.Shops = {
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop18', 
+        name = 'Robs Liquor', 
         inventory = {
             {
                 name = 'water',
@@ -1102,7 +1085,7 @@ Config.Shops = {
                 scale = 0.6,
             },
             text = 'E - Open Shop',
-            name = 'Shop19', 
+            name = 'Robs Liquor', 
             inventory = {
                 {
                     name = 'water',
@@ -1150,7 +1133,7 @@ Config.Shops = {
                 scale = 0.6,
             },
             text = 'E - Open Shop',
-            name = 'Shop20', 
+            name = 'Robs Liquor', 
             inventory = {
                 {
                     name = 'water',
@@ -1198,7 +1181,7 @@ Config.Shops = {
                 scale = 0.6,
             },
             text = 'E - Open Shop',
-            name = 'Shop21', 
+            name = 'Robs Liquor', 
             inventory = {
                 {
                     name = 'water',
@@ -1246,7 +1229,7 @@ Config.Shops = {
                 scale = 0.6,
             },
             text = 'E - Open Shop',
-            name = 'Shop22', 
+            name = 'Robs Liquor', 
             inventory = {
                 {
                     name = 'water',
@@ -1294,7 +1277,7 @@ Config.Shops = {
                 scale = 0.6,
             },
             text = 'E - Open Shop',
-            name = 'Shop23', 
+            name = 'Robs Liquor', 
             inventory = {
                 {
                     name = 'water',
@@ -1342,7 +1325,7 @@ Config.Shops = {
                 scale = 0.6,
             },
             text = 'E - Open Shop',
-            name = 'Shop24', 
+            name = 'Robs Liquor', 
             inventory = {
                 {
                     name = 'water',
@@ -1390,7 +1373,7 @@ Config.Shops = {
                 scale = 0.6,
             },
             text = 'E - Open Shop',
-            name = 'Shop25', 
+            name = 'Robs Liquor', 
             inventory = {
                 {
                     name = 'water',
@@ -1439,7 +1422,7 @@ Config.Shops = {
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop26', 
+        name = 'YouTool', 
         inventory = {
             {
                 name = 'acetone',
@@ -1528,7 +1511,7 @@ Config.Shops = {
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop27', 
+        name = 'YouTool', 
         inventory = {
             {
                 name = 'acetone',
@@ -1613,12 +1596,12 @@ Config.Shops = {
         coords = vector3(1775.936, 2587.57, 44.713),
         blip = {
             id = 52,
-            name = "Prison Shop",
+            name = "Prison Commissary",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop28', 
+        name = 'Prison Commissary', 
         inventory = {
             {
                 name = 'bread',
@@ -1646,9 +1629,9 @@ Config.Shops = {
     {
         job = 'police',
         coords = vector3(487.235, -997.108, 30.69),
+        name = 'Police Armoury',
         blip = {
             id = 110,
-            name = "Police Armoury",
             color = 5,
             scale = 0.6,
         },
@@ -1763,7 +1746,7 @@ Config.Shops = {
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop30', 
+        name = 'Ammunation', 
         inventory = {
             {
                 name = 'hsn_pistol_ammo',
@@ -1811,7 +1794,7 @@ Config.Shops = {
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop31', 
+        name = 'Ammunation', 
         inventory = {
             {
                 name = 'hsn_pistol_ammo',
@@ -1859,7 +1842,7 @@ Config.Shops = {
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop32', 
+        name = 'Ammunation', 
         inventory = {
             {
                 name = 'hsn_pistol_ammo',
@@ -1907,7 +1890,7 @@ Config.Shops = {
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop33', 
+        name = 'Ammunation', 
         inventory = {
             {
                 name = 'hsn_pistol_ammo',
@@ -1955,7 +1938,7 @@ Config.Shops = {
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop34', 
+        name = 'Ammunation', 
         inventory = {
             {
                 name = 'hsn_pistol_ammo',
@@ -2003,7 +1986,7 @@ Config.Shops = {
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop35', 
+        name = 'Ammunation', 
         inventory = {
             {
                 name = 'hsn_pistol_ammo',
@@ -2051,7 +2034,7 @@ Config.Shops = {
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop36', 
+        name = 'Ammunation', 
         inventory = {
             {
                 name = 'hsn_pistol_ammo',
@@ -2099,7 +2082,7 @@ Config.Shops = {
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop37', 
+        name = 'Ammunation', 
         inventory = {
             {
                 name = 'hsn_pistol_ammo',
@@ -2147,7 +2130,7 @@ Config.Shops = {
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop38', 
+        name = 'Ammunation', 
         inventory = {
             {
                 name = 'hsn_pistol_ammo',
@@ -2186,33 +2169,6 @@ Config.Shops = {
             },
         },
     },
-
-
-    --[[{
-        coords = vector3(316.3667, -200.783, 54.086),
-        blip = {
-            id = 52,
-            name = "Shop",
-            color = 5,
-            scale = 0.6,
-        },
-        text = 'E - Open Shop',
-        name = 'Shop', 
-        inventory = {
-            {
-                name = 'bread',
-                price = 15,
-                count = 200
-            },
-            {
-                name = 'WEAPON_PISTOL',
-                price = 1000,
-                count = 200,
-                metadata = {}
-            },
-        },
-    },]]
-
 }
 
 

--- a/config.lua
+++ b/config.lua
@@ -1632,6 +1632,7 @@ Config.Shops = {
         name = 'Police Armoury',
         blip = {
             id = 110,
+            name = 'Police Armoury',
             color = 5,
             scale = 0.6,
         },

--- a/config.lua
+++ b/config.lua
@@ -59,7 +59,7 @@ Config.DurabilityDecraseAmount = {
 }
 
 Config.CloseUiItems = {
-	"WEAPON_KNUCKLE",
+    "WEAPON_KNUCKLE",
 	"WEAPON_FLASHBANG",
 	"WEAPON_DBSHOTGUN",
 	"WEAPON_MACHINEPISTOL", 
@@ -1665,15 +1665,15 @@ Config.Shops = {
     },
     -- Police
     {
+        job = 'police',
         coords = vector3(487.235, -997.108, 30.69),
         blip = {
             id = 110,
-            name = "One Stop Police Shop",
+            name = "Police Armoury",
             color = 5,
             scale = 0.6,
         },
         text = 'E - Open Shop',
-        name = 'Shop29', 
         inventory = {
             {
                 name = 'burger',
@@ -1685,7 +1685,7 @@ Config.Shops = {
                 price = 10,
                 count = 200
             },
-            {
+--[[            {
                 name = 'handcuffs',
                 price = 15,
                 count = 200
@@ -1709,19 +1709,19 @@ Config.Shops = {
                 name = 'bulletproofpd',
                 price = 15,
                 count = 200
-            },
+            },]]
             {
-                name = 'ammo_pistol',
+                name = 'hsn_pistol_ammo',
                 price = 250,
                 count = 200
             },
             {
-                name = 'ammo_shotgun',
+                name = 'hsn_shotgun_ammo',
                 price = 15,
                 count = 200
             },
             {
-                name = 'ammo_rifle',
+                name = 'hsn_rifle_ammo',
                 price = 15,
                 count = 200
             },
@@ -1729,49 +1729,49 @@ Config.Shops = {
                 name = 'WEAPON_STUNGUN',
                 price = 150,
                 count = 1,
-                metadata = {}
+                metadata = { weaponlicense = 'POL' }
             },
             {
                 name = 'WEAPON_COMBATPISTOL',
                 price = 250,
                 count = 1,
-                metadata = {}
+                metadata = { weaponlicense = 'POL' }
             },
             {
                 name = 'WEAPON_PISTOL50',
                 price = 400,
                 count = 1,
-                metadata = {}
+                metadata = { weaponlicense = 'POL' }
             },
             {
                 name = 'WEAPON_PUMPSHOTGUN',
                 price = 500,
                 count = 1,
-                metadata = {}
+                metadata = { weaponlicense = 'POL' }
             },
             {
                 name = 'WEAPON_CARBINERIFLE',
                 price = 500,
                 count = 1,
-                metadata = {}
+                metadata = { weaponlicense = 'POL' }
             },
             {
                 name = 'WEAPON_NIGHTSTICK',
                 price = 50,
                 count = 1,
-                metadata = {}
+                metadata = { weaponlicense = 'POL' }
             },
             {
                 name = 'WEAPON_KNIFE',
                 price = 20,
                 count = 1,
-                metadata = {}
+                metadata = { weaponlicense = 'POL' }
             },
             {
                 name = 'WEAPON_FLASHLIGHT',
                 price = 15,
                 count = 1,
-                metadata = {}
+                metadata = { weaponlicense = 'POL' }
             },
         },
     },--WeaponShop
@@ -1779,7 +1779,7 @@ Config.Shops = {
         coords = vector3(-662.180, -934.961, 20.829),
         blip = {
             id = 110,
-            name = "Ammu Nationnation",
+            name = "Ammunation",
             color = 5,
             scale = 0.6,
         },
@@ -1787,7 +1787,7 @@ Config.Shops = {
         name = 'Shop30', 
         inventory = {
             {
-                name = 'ammo_pistol',
+                name = 'hsn_pistol_ammo',
                 price = 250,
                 count = 10
             },
@@ -1827,7 +1827,7 @@ Config.Shops = {
         coords = vector3(810.25, -2157.60, 28.62),
         blip = {
             id = 110,
-            name = "Ammu Nation",
+            name = "Ammunation",
             color = 5,
             scale = 0.6,
         },
@@ -1835,7 +1835,7 @@ Config.Shops = {
         name = 'Shop31', 
         inventory = {
             {
-                name = 'ammo_pistol',
+                name = 'hsn_pistol_ammo',
                 price = 250,
                 count = 10
             },
@@ -1875,7 +1875,7 @@ Config.Shops = {
         coords = vector3(1693.44, 3760.16, 33.71),
         blip = {
             id = 110,
-            name = "Ammu Nation",
+            name = "Ammunation",
             color = 5,
             scale = 0.6,
         },
@@ -1883,7 +1883,7 @@ Config.Shops = {
         name = 'Shop32', 
         inventory = {
             {
-                name = 'ammo_pistol',
+                name = 'hsn_pistol_ammo',
                 price = 250,
                 count = 10
             },
@@ -1923,7 +1923,7 @@ Config.Shops = {
         coords = vector3(-330.24, 6083.88, 30.45),
         blip = {
             id = 110,
-            name = "Ammu Nation",
+            name = "Ammunation",
             color = 5,
             scale = 0.6,
         },
@@ -1931,7 +1931,7 @@ Config.Shops = {
         name = 'Shop33', 
         inventory = {
             {
-                name = 'ammo_pistol',
+                name = 'hsn_pistol_ammo',
                 price = 250,
                 count = 10
             },
@@ -1971,7 +1971,7 @@ Config.Shops = {
         coords = vector3(252.63, -50.00, 68.94),
         blip = {
             id = 110,
-            name = "Ammu Nation",
+            name = "Ammunation",
             color = 5,
             scale = 0.6,
         },
@@ -1979,7 +1979,7 @@ Config.Shops = {
         name = 'Shop34', 
         inventory = {
             {
-                name = 'ammo_pistol',
+                name = 'hsn_pistol_ammo',
                 price = 250,
                 count = 10
             },
@@ -2019,7 +2019,7 @@ Config.Shops = {
         coords = vector3(22.56, -1109.89, 28.80),
         blip = {
             id = 110,
-            name = "Ammu Nation",
+            name = "Ammunation",
             color = 5,
             scale = 0.6,
         },
@@ -2027,7 +2027,7 @@ Config.Shops = {
         name = 'Shop35', 
         inventory = {
             {
-                name = 'ammo_pistol',
+                name = 'hsn_pistol_ammo',
                 price = 250,
                 count = 10
             },
@@ -2067,7 +2067,7 @@ Config.Shops = {
         coords = vector3(2567.69, 294.38, 107.73),
         blip = {
             id = 110,
-            name = "Ammu Nation",
+            name = "Ammunation",
             color = 5,
             scale = 0.6,
         },
@@ -2075,7 +2075,7 @@ Config.Shops = {
         name = 'Shop36', 
         inventory = {
             {
-                name = 'ammo_pistol',
+                name = 'hsn_pistol_ammo',
                 price = 250,
                 count = 10
             },
@@ -2115,7 +2115,7 @@ Config.Shops = {
         coords = vector3(-1117.58, 2698.61, 17.55),
         blip = {
             id = 110,
-            name = "Ammu Nation",
+            name = "Ammunation",
             color = 5,
             scale = 0.6,
         },
@@ -2123,7 +2123,7 @@ Config.Shops = {
         name = 'Shop37', 
         inventory = {
             {
-                name = 'ammo_pistol',
+                name = 'hsn_pistol_ammo',
                 price = 250,
                 count = 10
             },
@@ -2163,7 +2163,7 @@ Config.Shops = {
         coords = vector3(842.44, -1033.42, 27.19),
         blip = {
             id = 110,
-            name = "Ammu Nation",
+            name = "Ammunation",
             color = 5,
             scale = 0.6,
         },
@@ -2171,7 +2171,7 @@ Config.Shops = {
         name = 'Shop38', 
         inventory = {
             {
-                name = 'ammo_pistol',
+                name = 'hsn_pistol_ammo',
                 price = 250,
                 count = 10
             },
@@ -2233,7 +2233,9 @@ Config.Shops = {
             },
         },
     },]]
+
 }
+
 
 
 Config.Ammos = {
@@ -2354,3 +2356,48 @@ Config.Ammos = {
     },
 }
 
+
+Config.ItemList = {
+
+    {   item = 'burger',
+        thirst = 0,
+        hunger = 200000,
+        animDict = "mp_player_inteat@burger",
+        anim = "mp_player_int_eat_burger_fp",
+        model = "prop_cs_burger_01",
+        coords = { x = 0.02, y = 0.022, z = -0.02 },
+        rotation = { x = 0.0, y = 5.0, z = 0.0 },
+        useTime = 2500,
+        consume = 1
+
+    },
+
+    {   item = 'water',
+        thirst = 200000,
+        hunger = 0,
+        animDict = "mp_player_intdrink",
+        anim = "loop_bottle",
+        model = "prop_ld_flow_bottle",
+        coords = { x = 0.03, y = 0.0, z = 0.02 },
+        rotation = { x = 0.0, y = -13.5, z = -1.5 },
+        useTime = 2500,
+        consume = 1
+    },
+
+    {   item = 'bandage',
+        animDict = "missheistdockssetup1clipboard@idle_a",
+        anim = "idle_a",
+        flags = 49,
+        model = "prop_rolled_sock_02",
+        coords = { x = -0.14, y = 0.02, z = -0.08 },
+        rotation = { x = -50.0, y = -50.0, z = 0.0 },
+        useTime = 2500,
+        consume = 1
+    },
+
+    {   item = 'identification',
+        useTime = 0,
+        consume = 0
+    },
+
+}

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,6 @@
 Config = Config or {}
 Config.PlayerSlot = 51
-Config.DurabilityDecraseAmount = {
+Config.DurabilityDecreaseAmount = {
     ['WEAPON_PISTOL'] = 0.6,
     ['WEAPON_ADVANCEDRIFLE'] = 0.6,
     ['WEAPON_APPISTOL'] = 0.4,

--- a/html/script.js
+++ b/html/script.js
@@ -75,34 +75,35 @@
         if (quality == undefined || null) {
             quality = 100
         }
-        var color = "#0bb80b"
-        var text = "100"
+        var color = "#1d1d1de8"
+        var text = ''
         var width = 100
         if (quality == 100) {
             color = "#0bb80b",
-            text = 100,
+            text = '',
             width = quality
         } else if (quality >= 80 && quality <= 100) {
             color = "#0bb80b",
-            text = parseInt(quality).toFixed(2),
+            text = '',
             width = quality
         } else if (quality >= 50 && quality <= 80) {
             color = "#0bb80b81",
-            text = parseInt(quality).toFixed(2),
+            text = '',
             width = quality
         } else if (quality >= 20 && quality <= 50) {
             color = "#ca790fcb",
-            text = parseInt(quality).toFixed(2),
+            text = '',
             width = quality
         } else if (quality >= 1 && quality <= 20) {
-            color = parseInt(quality).toFixed(2),
-            text = "BAD",
+            color = '#5c0b0bcb;',
+            text = '',
             width = quality
         } else if (quality == 0) {
-            color = "crimson",
-            text = "BROKEN",
+            color = '#1d1d1de8',
+            text = '',
             width = 100
         }
+        //parseInt(quality).toFixed(2)
         return [color = color,text = text,width = width];
 
     }

--- a/html/script.js
+++ b/html/script.js
@@ -303,7 +303,11 @@
         if (Item != undefined) {
             $(".iteminfo").fadeIn(100);
             $(".iteminfo-label").html('<p>'+Item.label+'</p>')
-            $(".iteminfo-description").html('<p><strong>'+Item.description+'<p><strong>')
+            if (Item.metadata.description != undefined) {
+                $(".iteminfo-description").html('<p>'+Item.description+'<br>'+Item.metadata.description+'</p>')
+            } else {
+                $(".iteminfo-description").html('<p>'+Item.description+'</p>')
+            }
             if ((Item.name).split("_")[0] == "WEAPON") {
                 if (Item.metadata.weaponlicense == null || undefined) {
                     Item.metadata.weaponlicense = "HSN"
@@ -314,9 +318,9 @@
                 if (Item.metadata.ammo == null || undefined) {
                     Item.metadata.ammo = "Unknown"
                 }
-                $(".iteminfo-description").append('<p>Weapon License: <strong>'+Item.metadata.weaponlicense+'<p><strong>')
-                $(".iteminfo-description").append('<p>Durability: <strong>'+parseInt(Item.metadata.durability).toFixed(2)+''+'%<p><strong>')
-                $(".iteminfo-description").append('<p>Weapon Ammo : <strong>'+Item.metadata.ammo+'<p><strong>')
+                $(".iteminfo-description").append('<p>Serial Number: <strong>'+Item.metadata.weaponlicense+'</p></strong>')
+                $(".iteminfo-description").append('<p>Durability: <strong>'+parseInt(Item.metadata.durability).toFixed(2)+''+'%</p></strong>')
+                $(".iteminfo-description").append('<p>Weapon Ammo : <strong>'+Item.metadata.ammo+'</p></strong>')
             }
         } else {
             $(".iteminfo").fadeOut(100);

--- a/html/style.css
+++ b/html/style.css
@@ -227,17 +227,18 @@
     position: absolute;
     bottom: 2vh;
     width: 100%;
-    height: 1.8vh;
+    height: 5px;
     line-height: 1.6vh;
-    background-color: rgba(32, 6, 6, 0.15);
+    background-color: #1d1d1de8;
+    box-shadow: inset 0 0 1px 1px rgba(0, 0, 0, 0.2);
 }
 
 .item-slot-durability-bar {
     position: absolute;
-    height: 15px;
+    height: 5px;
     width: 100%;
     text-align: center;
-    box-shadow: inset 0 0 .25vh 0 rgba(0, 0, 0, 0.2);
+    box-shadow: inset 0 0 1px 1px rgba(0, 0, 0, 0.2);
 }
 
 

--- a/html/style.css
+++ b/html/style.css
@@ -2,7 +2,7 @@
     font-family: "Basic";
     margin: 0;
     padding: 0;
-    text-shadow: 0px 0px 0px black;
+    text-shadow: 1px 1px 0px black;
 }
 
 .inventory-main {
@@ -10,14 +10,13 @@
     height: 500px;
     padding: 20px;
     /*background-color: rgba(0, 0, 0, 0.2);*/
-    position: relative;
+    position: fixed;
     margin: auto;
     opacity: 0.9;
     top: 50%;
     left: 50%;
-    margin-left: -600px;
-    margin-top: -250px;
     display: block;
+    transform: translate(-50%, -50%);
 }
 
 .inventory-main-leftside {

--- a/html/style.css
+++ b/html/style.css
@@ -135,6 +135,7 @@
     
     background-color: rgba(0, 0, 0, 0.2);
     border: 1px solid rgba(255, 255, 255, 0.05);
+    text-shadow: 0px 0px 0px black !important;
 }
 
 #itembox-action {
@@ -146,6 +147,7 @@
     text-align: center;
     left: 0;
     right: 35px;
+    text-shadow: 0px 0px 0px black !important;
 }
 
 .itembox-img {
@@ -169,6 +171,7 @@
 #itembox-action > p {
     font-size: 12px;
     font-family: 'Basic';
+    text-shadow: 0px 0px 0px black !important;
 }
 
 #itembox-label {
@@ -178,6 +181,7 @@
     background-color: rgba(var(--main-label-color), 0.35);
     min-height: 2.2vh;
     height: fit-content;
+    text-shadow: 0px 0px 0px black !important;
 }
 
 #itembox-label > p {
@@ -188,12 +192,14 @@
     text-transform: lowercase;
     font-family: Verdana, Geneva, Tahoma, sans-serif;
     font-variant: small-caps;
+    text-shadow: 0px 0px 0px black !important;
 }
 
 .item-slot-img {
     max-width: 80%;
     max-height: 80%;
     padding: 0.5vw;
+    text-shadow: 0px 0px 0px black;
 }
 
 .item-slot-img img {
@@ -205,6 +211,7 @@
     height: auto;
     max-width: 100%;
     max-height: 100%;
+    text-shadow: 0px 0px 0px black;
 }
 
 .item-slot-label {
@@ -268,6 +275,7 @@
     right: 0;
     width: 35vh;
     height: 23vh;
+    text-shadow: 1px 1px 0px black;
 }
 
 

--- a/server.lua
+++ b/server.lua
@@ -881,6 +881,8 @@ RegisterServerEvent("hsn-inventory:server:useItem")
 AddEventHandler("hsn-inventory:server:useItem",function(item,slot)
     local src = source
     local Player = ESX.GetPlayerFromId(src)
+    local count = GetItemCount(Player.identifier, item.name)
+    if count == 0 then return end
     if playerInventory[Player.identifier][item.slot] ~= nil and playerInventory[Player.identifier][item.slot].name ~= nil then
         if item.name:find("WEAPON_") then
             if item.metadata.durability ~= nil then
@@ -914,6 +916,8 @@ AddEventHandler("hsn-inventory:server:useItemfromSlot",function(slot)
         if playerInventory[Player.identifier][slot] == nil then
             return
         end
+        local count = GetItemCount(Player.identifier, item.name)
+        if count == 0 then return end
         if playerInventory[Player.identifier][slot] ~= nil and playerInventory[Player.identifier][slot].name ~= nil then
             if playerInventory[Player.identifier][slot].name:find("WEAPON_") then
                 if playerInventory[Player.identifier][slot].metadata.durability > 0 then

--- a/server.lua
+++ b/server.lua
@@ -893,7 +893,8 @@ AddEventHandler("hsn-inventory:server:useItem",function(item,slot)
             end
         else
             if ESX.UsableItemsCallbacks[item.name] ~= nil then
-                TriggerClientEvent("hsn-inventory:client:esxUseItem",src,item)
+                TriggerClientEvent('hsn-inventory:useItem', src, item)
+                
                 --TriggerClientEvent("hsn-inventory:client:addItemNotify",source,ESXItems[item.name],'Used 1x')
             end
         end
@@ -918,7 +919,7 @@ AddEventHandler("hsn-inventory:server:useItemfromSlot",function(slot)
                     TriggerClientEvent("notification",src,'This weapon is broken',2)
                 end
             else
-                TriggerClientEvent("hsn-inventory:client:esxUseItem",src,playerInventory[Player.identifier][slot])
+                TriggerClientEvent("hsn-inventory:useItem",src,playerInventory[Player.identifier][slot])
                 --TriggerClientEvent("hsn-inventory:client:addItemNotify",source,ESXItems[playerInventory[Player.identifier][slot].name],'Used 1x')
             end
         end
@@ -1195,10 +1196,7 @@ function getPlayerIdentification(xPlayer)
 end
 
 for k, v in pairs(Config.ItemList) do
-    ESX.RegisterUsableItem(v.item, function(source)
-        local xPlayer = ESX.GetPlayerFromId(source)
-        local label = ESXItems[v.item].label
-
-        TriggerClientEvent('hsn-inventory:useItem', source, k, label)
+    ESX.RegisterUsableItem(v, function(source)
+        TriggerClientEvent('hsn-inventory:useItem', source, k)
     end)
 end

--- a/server.lua
+++ b/server.lua
@@ -893,6 +893,11 @@ AddEventHandler("hsn-inventory:server:useItem",function(item,slot)
             end
         else
             if ESX.UsableItemsCallbacks[item.name] ~= nil then
+                if item.name:find("hsn") then
+                    local weps = Config.Ammos[item.name]
+                    TriggerClientEvent("hsn-inventory:addAmmo",src,weps,item.name)
+                    return
+                end
                 TriggerClientEvent('hsn-inventory:useItem', src, item)
                 
                 --TriggerClientEvent("hsn-inventory:client:addItemNotify",source,ESXItems[item.name],'Used 1x')
@@ -919,6 +924,11 @@ AddEventHandler("hsn-inventory:server:useItemfromSlot",function(slot)
                     TriggerClientEvent("notification",src,'This weapon is broken',2)
                 end
             else
+                if playerInventory[Player.identifier][slot].name:find("hsn") then
+                    local weps = Config.Ammos[playerInventory[Player.identifier][slot].name]
+                    TriggerClientEvent("hsn-inventory:addAmmo",src,weps,playerInventory[Player.identifier][slot].name)
+                    return
+                end
                 TriggerClientEvent("hsn-inventory:useItem",src,playerInventory[Player.identifier][slot])
                 --TriggerClientEvent("hsn-inventory:client:addItemNotify",source,ESXItems[playerInventory[Player.identifier][slot].name],'Used 1x')
             end
@@ -940,10 +950,10 @@ AddEventHandler("hsn-inventory:server:decreasedurability",function(slot, amount)
                     TriggerClientEvent("notification",src,'This weapon is broken',2)
                     return
                 end
-                if Config.DurabilitydecreaseAmount[playerInventory[Player.identifier][slot].name] == nil and not amount then
+                if Config.DurabilityDecreaseAmount[playerInventory[Player.identifier][slot].name] == nil and not amount then
                     decreaseamount = 0.5
-                elseif Config.DurabilitydecreaseAmount[playerInventory[Player.identifier][slot].name] then
-                    decreaseamount = Config.DurabilitydecreaseAmount[playerInventory[Player.identifier][slot].name]
+                elseif Config.DurabilityDecreaseAmount[playerInventory[Player.identifier][slot].name] then
+                    decreaseamount = Config.DurabilityDecreaseAmount[playerInventory[Player.identifier][slot].name]
                 else
                     decreaseamount = amount
                 end
@@ -973,16 +983,9 @@ AddEventHandler("hsn-inventory:server:addweaponAmmo",function(slot,count)
     end
 end)
 
-Citizen.CreateThread(function()
-    for k,v in pairs(Config.Ammos) do
-        ESX.RegisterUsableItem(k,function(source)
-            TriggerClientEvent("hsn-inventory:addAmmo",source,v,k)
-        end)
-    end
-end)
-
 RegisterServerEvent("hsn-inventory:server:removeItem")
 AddEventHandler("hsn-inventory:server:removeItem",function(item, count)
+    if count == 0 then return end
     local src = source
     local Player = ESX.GetPlayerFromId(src)
     if item == nil then
@@ -1195,8 +1198,15 @@ function getPlayerIdentification(xPlayer)
     return ('Name: %s | Sex: %s | Height: %s<br>DOB: %s (%s)'):format( xPlayer.getName(), xPlayer.get('sex'), xPlayer.get('height'), xPlayer.get('dateofbirth'), xPlayer.getIdentifier() )
 end
 
+
 for k, v in pairs(Config.ItemList) do
     ESX.RegisterUsableItem(v, function(source)
         TriggerClientEvent('hsn-inventory:useItem', source, k)
+    end)
+end
+
+for k,v in pairs(Config.Ammos) do
+    ESX.RegisterUsableItem(k,function(source)
+        TriggerClientEvent("hsn-inventory:addAmmo",source,v,k)
     end)
 end

--- a/server.lua
+++ b/server.lua
@@ -916,7 +916,7 @@ AddEventHandler("hsn-inventory:server:useItemfromSlot",function(slot)
         if playerInventory[Player.identifier][slot] == nil then
             return
         end
-        local count = GetItemCount(Player.identifier, item.name)
+        local count = GetItemCount(Player.identifier, playerInventory[Player.identifier][slot].name)
         if count == 0 then return end
         if playerInventory[Player.identifier][slot] ~= nil and playerInventory[Player.identifier][slot].name ~= nil then
             if playerInventory[Player.identifier][slot].name:find("WEAPON_") then

--- a/server.lua
+++ b/server.lua
@@ -83,7 +83,6 @@ AddPlayerInventory = function(identifier, item, count, slot, metadata)
                     if playerInventory[identifier][i] == nil then
                         if metadata == nil then
                             metadata = {}
-                            metadata.description = ''
                             metadata.durability = 100
                             metadata.ammo = 0
                         end

--- a/server.lua
+++ b/server.lua
@@ -959,7 +959,7 @@ AddEventHandler("hsn-inventory:server:decreasedurability",function(slot, amount)
                 end
                 playerInventory[Player.identifier][slot].metadata.durability = playerInventory[Player.identifier][slot].metadata.durability - decreaseamount
                 if playerInventory[Player.identifier][slot].metadata.durability == 0 then
-                    TriggerServerEvent('hsn-inventory:server:removeItem', data.item, 1)
+                    TriggerServerEvent('hsn-inventory:server:removeItem', src, data.item, 1)
                 end
             end
             if playerInventory[Player.identifier][slot].metadata.ammo ~= nil then
@@ -984,7 +984,7 @@ AddEventHandler("hsn-inventory:server:addweaponAmmo",function(slot,count)
 end)
 
 RegisterServerEvent("hsn-inventory:server:removeItem")
-AddEventHandler("hsn-inventory:server:removeItem",function(item, count)
+AddEventHandler("hsn-inventory:server:removeItem",function(source, item, count)
     if count == 0 then return end
     local src = source
     local Player = ESX.GetPlayerFromId(src)

--- a/server.lua
+++ b/server.lua
@@ -894,16 +894,12 @@ AddEventHandler("hsn-inventory:server:useItem",function(item,slot)
                 end
             end
         else
-            if ESX.UsableItemsCallbacks[item.name] ~= nil then
-                if item.name:find("hsn") then
-                    local weps = Config.Ammos[item.name]
-                    TriggerClientEvent("hsn-inventory:addAmmo",src,weps,item.name)
-                    return
-                end
-                TriggerClientEvent('hsn-inventory:useItem', src, item)
-                
-                --TriggerClientEvent("hsn-inventory:client:addItemNotify",source,ESXItems[item.name],'Used 1x')
+            if item.name:find("hsn") then
+                local weps = Config.Ammos[item.name]
+                TriggerClientEvent("hsn-inventory:addAmmo",src,weps,item.name)
+                return
             end
+            TriggerClientEvent('hsn-inventory:useItem', src, item)
         end
     end
 end)
@@ -1200,17 +1196,4 @@ end)
 
 function getPlayerIdentification(xPlayer)
     return ('Name: %s | Sex: %s | Height: %s<br>DOB: %s (%s)'):format( xPlayer.getName(), xPlayer.get('sex'), xPlayer.get('height'), xPlayer.get('dateofbirth'), xPlayer.getIdentifier() )
-end
-
-
-for k, v in pairs(Config.ItemList) do
-    ESX.RegisterUsableItem(v, function(source)
-        TriggerClientEvent('hsn-inventory:useItem', source, k)
-    end)
-end
-
-for k,v in pairs(Config.Ammos) do
-    ESX.RegisterUsableItem(k,function(source)
-        TriggerClientEvent("hsn-inventory:addAmmo",source,v,k)
-    end)
 end

--- a/server.lua
+++ b/server.lua
@@ -83,6 +83,7 @@ AddPlayerInventory = function(identifier, item, count, slot, metadata)
                     if playerInventory[identifier][i] == nil then
                         if metadata == nil then
                             metadata = {}
+                            metadata.description = ''
                             metadata.durability = 100
                             metadata.ammo = 0
                         end
@@ -109,7 +110,7 @@ AddPlayerInventory = function(identifier, item, count, slot, metadata)
                     playerInventory[identifier][slot] = {name = item ,label = ESXItems[item].label, weight = ESXItems[item].weight, slot = i, count = count, description = ESXItems[item].description, metadata = metadata or {}, stackable = ESXItems[item].stackable, closeonuse = ESXItems[item].closeonuse}
                 else
                     for i = 1, Config.PlayerSlot do
-                        if playerInventory[identifier][i] ~= nil and playerInventory[identifier][i].name == item and playerInventory[identifier][i].metadata.description == metadata.description then
+                        if playerInventory[identifier][i] ~= nil and playerInventory[identifier][i].name == item then
                             playerInventory[identifier][i] = {name = item ,label = ESXItems[item].label, weight = ESXItems[item].weight, slot = i, count = playerInventory[identifier][i].count + count, description = ESXItems[item].description, metadata = metadata or {}, stackable = ESXItems[item].stackable, closeonuse = ESXItems[item].closeonuse}
                             break
                         else

--- a/server.lua
+++ b/server.lua
@@ -646,7 +646,7 @@ AddEventHandler("hsn-inventory:server:openInventory",function(data)
         elseif data.type == 'shop' then
             Shops[data.id.name] = {}
             Shops[data.id.name].inventory = SetupShopItems(data.id)
-            Shops[data.id.name].name = data.id.blip.name
+            Shops[data.id.name].name = data.id.name or 'Shop'
             Shops[data.id.name].type = 'shop'
             Shops[data.id.name].slots = #Shops[data.id.name].inventory + 1
             TriggerClientEvent("hsn-inventory:client:openInventory",src,playerInventory[Player.identifier],Shops[data.id.name])


### PR DESCRIPTION
## CLIENT  
Support restricting access to shops based on job
Set shop name to display as blip name
Add checks for isDead and isCuffed
Add check for opened inventory
Allow movement if accessing own inventory
Allow certain keys if in any inventory (for voice)
Support different firearm serial numbers (HSN - default; POL - police)
Use mythic_notify for displaying notifications
Add support for food, drinks, and bandages
Changed notification messages

## SERVER
Support setting metadata.weaponlicense based on the store (police armoury sells POL weapons)
Create identification for players with metadata
Save and load inventories when script restarts
Register usable items from config

## CONFIG
Fix store names
Fix ammo names
Set weapons from police armoury to be receive a 'POL' serial number
Add an ItemList to be registered with the server

## HTML
Fix inventory position to be correctly centered
Display metadata.description

## OTHER
Added event to send out equipped weapon data
Compatibility with my WIP evidence resource (https://github.com/thelindat/linden_evidence)
<img src='https://i.imgur.com/dkhZ4Ku.png'>