### PR TITLE
More fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Further development of this resource is continuing at <a href='https://github.co
 <p align='center'>Requires OneSync and either <a href='https://github.com/esx-framework/es_extended/tree/v1-final'>ESX v1 Final</a>, or <a href='https://github.com/extendedmode/extendedmode'>ExtendedMode</a><br>If you are looking to upgrade or starting fresh, a modified framework is <a href='https://github.com/thelindat/extendedmode-hsn-inventory-compatibility'>available here</a>.
 
 ## Dependencies
-[ghmattimysql](https://github.com/GHMatti/ghmattimysql)  
+[ghmattimysql](https://github.com/GHMatti/ghmattimysql/releases)  
 [mythic_progbar](https://github.com/thelindat/mythic_progbar)  
 [mythic_notify](https://github.com/FlawwsX/mythic_notify)  
 

--- a/client.lua
+++ b/client.lua
@@ -225,6 +225,7 @@ end
 
 RegisterNetEvent('hsn-inventory:client:openInventory')
 AddEventHandler('hsn-inventory:client:openInventory',function(inventory,other)
+	if not playerName then return end
 	invOpen = true
 	ESX.SetPlayerData('inventory', inventory)
 	SendNUIMessage({
@@ -253,6 +254,7 @@ end)
 
 RegisterNetEvent('hsn-inventory:client:refreshInventory')
 AddEventHandler('hsn-inventory:client:refreshInventory',function(inventory)
+	if not playerName then return end
 	SendNUIMessage({
 		message = 'refresh',
 		inventory = inventory,

--- a/client.lua
+++ b/client.lua
@@ -203,7 +203,7 @@ RegisterCommand('vehinv', function()
 		local plate = GetVehicleNumberPlateText(vehicle)
 		OpenGloveBox(plate)
 	end
-end,false)
+end, false)
 	
 RegisterCommand('inventory', function()
 	if not playerName then return end
@@ -571,7 +571,8 @@ AddEventHandler('hsn-inventory:client:checkweapon',function(item)
 	end
 end)
 
-RegisterCommand('steal',function()
+-- DISABLE FOR NOW, works very inconsistently and has issues with duping
+--[[RegisterCommand('steal',function()
 	local ped = playerPed
 	if not IsPedInAnyVehicle(ped, true) and not isDead and not isCuffed then	 
 		openTargetInventory()
@@ -588,7 +589,7 @@ function openTargetInventory()
 	else
 		TriggerEvent('hsn-inventory:notification','There is nobody nearby')
 	end
-end
+end]]
 
 local nui_focus = {false, false}
 function SetNuiFocusAdvanced(hasFocus, hasCursor, allowMovement)

--- a/client.lua
+++ b/client.lua
@@ -69,6 +69,15 @@ AddEventHandler('esx:onPlayerSpawn', function(spawn)
 	isDead = false
 end)
 
+AddEventHandler('playerSpawned', function(spawn)
+	isDead = false
+end)
+
+AddEventHandler('esx_ambulancejob:setDeathStatus', function(status)
+	isDead = status
+end)
+
+
 RegisterNetEvent('esx_policejob:handcuff')
 AddEventHandler('esx_policejob:handcuff', function()
 	isCuffed = not isCuffed

--- a/client.lua
+++ b/client.lua
@@ -485,7 +485,7 @@ AddEventHandler('hsn-inventory:client:weapon',function(item)
 	if currentWeapon and currentWeapon.item.metadata.weaponlicense == newWeapon then
 		currentWeapon.item.metadata.ammo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
 		TriggerEvent('hsn-inventory:weaponaway')
-		while usingItem do Citizen.Wait(100) end
+		Citizen.Wait(1600)
 		RemoveWeaponFromPed(playerPed, GetHashKey(item.name))
 		SetCurrentPedWeapon(playerPed, 'WEAPON_UNARMED', true)
 		currentWeapon = nil

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,7 +1,7 @@
 fx_version 'adamant'
 game 'gta5'
 description 'https://github.com/hsnnnnn/hsn-inventory'
-version '1.4.10'
+version '1.4.11'
 
 client_scripts {
 	'config.lua',

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,7 +1,7 @@
 fx_version 'adamant'
 game 'gta5'
 description 'https://github.com/hsnnnnn/hsn-inventory'
-version '1.4.9'
+version '1.4.10'
 
 client_scripts {
 	'config.lua',

--- a/html/script.js
+++ b/html/script.js
@@ -33,7 +33,7 @@
 			toplamkg = 0
 		}
 	}
-	console.log("[hsn-inventory] = Successfully Loaded :)")
+	console.log("Successfully Loaded :)")
 	Display(false)
 	window.addEventListener('message', function(event) {
 		if (event.data.message == 'openinventory') {
@@ -45,6 +45,7 @@
 
 		} else if (event.data.message == 'refresh') {
 			HSN.RefreshInventory(event.data)
+			DragAndDrop()
 		} else if (event.data.message == 'hsn-hotbar') {
 			HSN.Hotbar(event.data.inventory) 
 		}else if (event.data.message == "notify") {
@@ -114,6 +115,10 @@
 
 	HSN.RefreshInventory = function(data) {
 		toplamkg = 0
+		for(i = 1; i < (data.slots); i++) {
+			$(".inventory-main-leftside").find("[inventory-slot=" + i + "]").remove();
+			$(".inventory-main-leftside").append('<div class="ItemBoxes" inventory-slot=' + i +'></div> ')
+		}
 		$.each(data.inventory, function (i, item) {
 			if (item != null) {
 				toplamkg = toplamkg +(item.weight * item.count);
@@ -148,7 +153,7 @@
 	}
 
 
-	HSN.SetupInventory = function(data) {	 
+	HSN.SetupInventory = function(data) {
 		maxweight = data.maxweight
 		$('.playername').html(data.name)
 		for(i = 1; i < (data.slots); i++) {
@@ -366,6 +371,7 @@
 	});
 	 
 
+	// really need to redo a lot of this stuff to validate items existences
 	SwapItems = function(fromInventory, toInventory, fromSlot, toSlot) {
 		fromItem = fromInventory.find("[inventory-slot=" + fromSlot + "]").data("ItemData");
 		inv = fromInventory.data('invTier')
@@ -428,6 +434,7 @@
 							invid: toinvId,
 							invid2 :toinvId2
 						}));
+						
 						HSN.RemoveItemFromSlot(fromInventory, fromSlot)
 				} else if (fromItem.name !== toItem.name && inv2 == inv) { // swap
 					if ((toItem.name).split("_")[0] == "WEAPON" && toItem.metadata.durability !== undefined || null) {
@@ -499,6 +506,7 @@
 			//inv = from
 			//inv2 == to
 			if (inv2 !== 'Playerinv') {availableweight = rightfreeweight} else {availableweight = playerfreeweight}
+			
 			if (availableweight !== 0 && (fromItem.weight * count) <= availableweight) {
 				if (count <= fromItem.count) {
 					if(((fromItem.name).split("_")[0] == "WEAPON" && fromItem.metadata.durability !== undefined || null)) {

--- a/server.lua
+++ b/server.lua
@@ -12,7 +12,6 @@ local Trunks = {}
 local notready = true
 if GetConvar('onesync_enableInfinity', false) == 'true' or GetConvar('onesync', false) == 'on' then oneSync = true end
 
-
 TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 
 ESX.RegisterServerCallback('hsn-inventory:getData',function(source, cb)
@@ -289,7 +288,8 @@ AddEventHandler('hsn-inventory:server:saveInventoryData',function(data)
 					end
 				end
 		elseif data.frominv ~= data.toinv and (data.toinv == 'TargetPlayer' and data.frominv == 'Playerinv') then
-			local playerId = string.sub(data.invid,13)
+			--local playerId = string.sub(data.invid,13)
+			local playerId = string.gsub(data.invid, 'Player', '')
 			local targetplayer = ESX.GetPlayerFromId(playerId)
 			if playerInventory[targetplayer.identifier] ~= nil then
 				if data.type == 'swap' then
@@ -326,8 +326,9 @@ AddEventHandler('hsn-inventory:server:saveInventoryData',function(data)
 				end
 			end
 		elseif data.frominv ~= data.toinv and (data.toinv == 'Playerinv' and data.frominv == 'TargetPlayer') then
-			local playerId = string.sub(data.invid2,13)
-			local targetplayer = ESX.GetPlayerFromId(playerId)local targetplayer = tPlayer
+			--local playerId = string.sub(data.invid2,13)
+			local playerId = string.gsub(data.invid, 'Player', '')
+			local targetplayer = ESX.GetPlayerFromId(playerId)
 			if playerInventory[targetplayer.identifier] ~= nil then
 				if data.type == 'swap' then
 					if IfInventoryCanCarry(playerInventory[Player.identifier],Config.MaxWeight, (data.toItem.weight * data.toItem.count)) then

--- a/server.lua
+++ b/server.lua
@@ -1190,7 +1190,7 @@ getItem = function(src, item, metadata)
 	end
 	local inventory = playerInventory[Player.identifier]
 	local xItem = ESXItems[item]
-	if not xItem then print('^1[hsn-inventory]^3 Item '.. item ..' does not exist^7')
+	if not xItem then print('^1[hsn-inventory]^3 Item '.. item ..' does not exist^7') end
 	xItem.metadata = {type = metadata}
 	xItem.count = 0
 	for k, v in pairs(inventory) do

--- a/server.lua
+++ b/server.lua
@@ -273,7 +273,7 @@ AddEventHandler('hsn-inventory:server:saveInventoryData',function(data)
 				ItemNotify(src,data.oldslotItem.name,data.oldslotItem.count,'Removed')
 			end
 		elseif data.frominv == data.toinv and (data.frominv == 'TargetPlayer') then
-			local playerId = string.sub(data.invid,13)
+			local playerId = string.gsub(data.invid, 'Player', '')
 			local targetplayer = ESX.GetPlayerFromId(playerId)
 				if playerInventory[targetplayer.identifier] ~= nil then
 					if data.type == 'swap' then
@@ -288,7 +288,6 @@ AddEventHandler('hsn-inventory:server:saveInventoryData',function(data)
 					end
 				end
 		elseif data.frominv ~= data.toinv and (data.toinv == 'TargetPlayer' and data.frominv == 'Playerinv') then
-			--local playerId = string.sub(data.invid,13)
 			local playerId = string.gsub(data.invid, 'Player', '')
 			local targetplayer = ESX.GetPlayerFromId(playerId)
 			if playerInventory[targetplayer.identifier] ~= nil then
@@ -326,8 +325,7 @@ AddEventHandler('hsn-inventory:server:saveInventoryData',function(data)
 				end
 			end
 		elseif data.frominv ~= data.toinv and (data.toinv == 'Playerinv' and data.frominv == 'TargetPlayer') then
-			--local playerId = string.sub(data.invid2,13)
-			local playerId = string.gsub(data.invid, 'Player', '')
+			local playerId = string.gsub(data.invid2, 'Player', '')
 			local targetplayer = ESX.GetPlayerFromId(playerId)
 			if playerInventory[targetplayer.identifier] ~= nil then
 				if data.type == 'swap' then

--- a/server.lua
+++ b/server.lua
@@ -593,6 +593,7 @@ AddEventHandler('hsn-inventory:server:saveInventoryData',function(data)
 			elseif data.type == 'freeslot' then
 				if IfInventoryCanCarry(playerInventory[Player.identifier],Config.MaxWeight, (data.item.weight * data.item.count)) then
 					local money = Player.getMoney()
+					if money and not data.item.price then TriggerClientEvent('hsn-inventory:client:refreshInventory',src,playerInventory[Player.identifier]) return end
 					if (money >= (data.item.price * data.item.count)) then
 						Player.removeMoney(data.item.price * data.item.count)
 						ItemNotify(src,data.item.name,data.item.count,'Added')
@@ -626,6 +627,7 @@ AddEventHandler('hsn-inventory:server:saveInventoryData',function(data)
 			elseif data.type == 'yarimswap' then
 				local money = Player.getMoney()
 				if IfInventoryCanCarry(playerInventory[Player.identifier],Config.MaxWeight, (data.newslotItem.weight * data.newslotItem.count)) then
+					if money and not data.newslotItem.price then TriggerClientEvent('hsn-inventory:client:refreshInventory',src,playerInventory[Player.identifier]) return end
 					if (money >= (data.newslotItem.price *  data.newslotItem.count)) then
 						if data.newslotItem.name:find('WEAPON_') then
 							if Config.Throwable[data.newslotItem.name] then

--- a/server.lua
+++ b/server.lua
@@ -795,8 +795,8 @@ OpenStash = function(source, stash)
 	end
 end
 
-
-RegisterServerEvent('hsn-inventory:server:openTargetInventory')
+-- DISABLE FOR NOW, works very inconsistently and has issues with duping
+--[[RegisterServerEvent('hsn-inventory:server:openTargetInventory')
 AddEventHandler('hsn-inventory:server:openTargetInventory',function(TargetId)
 	if notready then return end
 	local Player = ESX.GetPlayerFromId(source)
@@ -815,7 +815,7 @@ AddEventHandler('hsn-inventory:server:openTargetInventory',function(TargetId)
 			TriggerClientEvent('hsn-inventory:client:openInventory',source,playerInventory[Player.identifier], data)
 		end
 	end
-end)
+end)]]
 
 RegisterServerEvent('hsn-inventory:server:saveInventory')
 AddEventHandler('hsn-inventory:server:saveInventory',function(data)

--- a/server.lua
+++ b/server.lua
@@ -800,10 +800,10 @@ AddEventHandler('hsn-inventory:server:openTargetInventory',function(TargetId)
 	local Player = ESX.GetPlayerFromId(source)
 	local tPlayer = ESX.GetPlayerFromId(TargetId)
 	if source == TargetId then tPlayer = nil end -- Don't allow source and targetid to match
-	if playerInventory[tPlayer.identifier] == nil then
-		playerInventory[tPlayer.identifier] = {}
-	end
 	if tPlayer and Player then
+		if playerInventory[tPlayer.identifier] == nil then
+			playerInventory[tPlayer.identifier] = {}
+		end
 		if checkOpenable(source, 'Player'..TargetId, GetEntityCoords(GetPlayerPed(TargetId))) then
 			local data = {}
 			data.name = 'Player'..TargetId -- do not touch
@@ -1148,10 +1148,10 @@ AddEventHandler('hsn-inventory:client:removeItem',function(item, count, metadata
 end)
 
 removeItem = function(src, item, count, metadata, slot)
-	local Player = ESX.GetPlayerFromId(src)
 	if item == nil then
 		return
 	end
+	local Player = ESX.GetPlayerFromId(src)
 	if count == nil then
 		count = 1
 	end
@@ -1159,10 +1159,10 @@ removeItem = function(src, item, count, metadata, slot)
 end
 
 addItem = function(src, item, count, metadata)
-	local Player = ESX.GetPlayerFromId(src)
 	if item == nil then
 		return
 	end
+	local Player = ESX.GetPlayerFromId(src)
 	if count == nil then
 		count = 1
 	end
@@ -1174,6 +1174,9 @@ addItem = function(src, item, count, metadata)
 end
 
 getItemCount = function(src, item)
+	if item == nil then
+		return
+	end
 	local Player = ESX.GetPlayerFromId(src)
 	if playerInventory[Player.identifier] == nil then
 		return
@@ -1183,6 +1186,9 @@ getItemCount = function(src, item)
 end
 
 getItem = function(src, item, metadata)
+	if item == nil then
+		return
+	end
 	local Player = ESX.GetPlayerFromId(src)
 	if playerInventory[Player.identifier] == nil then
 		return
@@ -1201,6 +1207,9 @@ getItem = function(src, item, metadata)
 end
 
 canCarryItem = function(src, item, count)
+	if item == nil then
+		return
+	end
 	local weight = 0
 	local newWeight = (ESXItems[item].weight * count)
 	local returnData = false
@@ -1220,6 +1229,9 @@ end
 
 
 useItem = function(src, item, slot)
+	if item == nil then
+		return
+	end
 	local metadata = item.metadata.type
 	if Config.ItemList[item.name] then
 		if not next(Config.ItemList[item.name]) then return end
@@ -1230,6 +1242,9 @@ useItem = function(src, item, slot)
 end
 
 ESX.RegisterServerCallback('hsn-inventory:getItemCount',function(source, cb, item)
+	if item == nil then
+		return
+	end
 	local src = source
 	local Player = ESX.GetPlayerFromId(src)
 	if playerInventory[Player.identifier] == nil then
@@ -1240,6 +1255,9 @@ ESX.RegisterServerCallback('hsn-inventory:getItemCount',function(source, cb, ite
 end)
 
 ESX.RegisterServerCallback('hsn-inventory:getItem',function(source, cb, item, metadata)
+	if item == nil then
+		return
+	end
 	local src = source
 	local Player = ESX.GetPlayerFromId(src)
 	if playerInventory[Player.identifier] == nil then

--- a/server.lua
+++ b/server.lua
@@ -1190,6 +1190,7 @@ getItem = function(src, item, metadata)
 	end
 	local inventory = playerInventory[Player.identifier]
 	local xItem = ESXItems[item]
+	if not xItem then print('^1[hsn-inventory]^3 Item '.. item ..' does not exist^7')
 	xItem.metadata = {type = metadata}
 	xItem.count = 0
 	for k, v in pairs(inventory) do


### PR DESCRIPTION
## Fixes
* Disable opening target inventories (/steal) for now - inconsistent and potential duping
* Add some more events to set `isDead` to the correct value (inventory not opening after revive)
* Check if receiving nil value for item when performing inventoryitem functions
* When failing to purchase an item the inventory will now refresh (prevents duping)

The javascript needs a lot of work regarding item validation, swapping, and stacking.